### PR TITLE
hide outcome::result into libp2p namespace

### DIFF
--- a/include/libp2p/outcome/outcome.hpp
+++ b/include/libp2p/outcome/outcome.hpp
@@ -20,9 +20,11 @@
  * since it is not necessary outside of outcome internals
  * it can be safely undefined
  */
+#ifdef __cpp_sized_deallocation
 #undef __cpp_sized_deallocation
+#endif
 
-namespace outcome {
+namespace libp2p::outcome {
   using namespace BOOST_OUTCOME_V2_NAMESPACE;  // NOLINT
 
   template <class R, class S = std::error_code,

--- a/src/protocol_muxer/multiselect/message_manager.cpp
+++ b/src/protocol_muxer/multiselect/message_manager.cpp
@@ -29,6 +29,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::protocol_muxer, MessageManager::ParseError,
 namespace {
   using libp2p::common::ByteArray;
   using libp2p::multi::UVarint;
+  using libp2p::outcome::result;
   using MultiselectMessage =
       libp2p::protocol_muxer::MessageManager::MultiselectMessage;
 
@@ -57,7 +58,7 @@ namespace {
    * @param line to be seeked
    * @return varint, if it was retrieved; error otherwise
    */
-  outcome::result<UVarint> getVarint(std::string_view line) {
+  result<UVarint> getVarint(std::string_view line) {
     using ParseError = libp2p::protocol_muxer::MessageManager::ParseError;
 
     if (line.empty()) {
@@ -80,7 +81,7 @@ namespace {
    * @param msg of the specified format
    * @return pure protocol string with \n thrown away
    */
-  outcome::result<std::string> parseProtocolLine(std::string_view msg) {
+  result<std::string> parseProtocolLine(std::string_view msg) {
     using ParseError = libp2p::protocol_muxer::MessageManager::ParseError;
 
     auto new_line_byte = msg.find('\n');
@@ -96,7 +97,7 @@ namespace {
    * @param line of the specified format
    * @return pure protocol with varint and \n thrown away
    */
-  outcome::result<std::string> parseProtocolsLine(std::string_view line) {
+  result<std::string> parseProtocolsLine(std::string_view line) {
     using ParseError = libp2p::protocol_muxer::MessageManager::ParseError;
 
     auto varint_res = getVarint(line);

--- a/test/deps/outcome_test.cpp
+++ b/test/deps/outcome_test.cpp
@@ -9,6 +9,8 @@
 
 using std::string_literals::operator""s;
 
+using namespace libp2p;
+
 #define ILLEGAL_CHAR_MSG "illegal char"s
 #define DIV_0_MSG "division by 0"s
 

--- a/test/libp2p/crypto/marshaller_test.cpp
+++ b/test/libp2p/crypto/marshaller_test.cpp
@@ -42,7 +42,7 @@ class Pubkey : public testing::TestWithParam<KeyCase<PublicKey>> {
  public:
   void SetUp() override {
     ON_CALL(*validator_, validate(::testing::An<const PublicKey &>()))
-        .WillByDefault(Return(outcome::success()));
+        .WillByDefault(Return(libp2p::outcome::success()));
   }
   std::shared_ptr<KeyValidatorMock> validator_ =
       std::make_shared<KeyValidatorMock>();
@@ -53,7 +53,7 @@ class Privkey : public testing::TestWithParam<KeyCase<PrivateKey>> {
  public:
   void SetUp() override {
     ON_CALL(*validator_, validate(::testing::An<const PrivateKey &>()))
-        .WillByDefault(Return(outcome::success()));
+        .WillByDefault(Return(libp2p::outcome::success()));
   }
 
   std::shared_ptr<KeyValidatorMock> validator_ =

--- a/test/libp2p/multi/cid_test.cpp
+++ b/test/libp2p/multi/cid_test.cpp
@@ -44,9 +44,8 @@ TEST(CidTest, PrettyString) {
 }
 
 class CidEncodeTest
-    : public testing::TestWithParam<
-          std::pair<ContentIdentifier, outcome::result<std::vector<uint8_t>>>> {
-};
+    : public testing::TestWithParam<std::pair<
+          ContentIdentifier, libp2p::outcome::result<std::vector<uint8_t>>>> {};
 
 TEST(CidTest, Create) {
   ContentIdentifier c(ContentIdentifier::Version::V0, MulticodecType::IDENTITY,
@@ -69,8 +68,8 @@ TEST_P(CidEncodeTest, Encode) {
 }
 
 class CidDecodeTest
-    : public testing::TestWithParam<
-          std::pair<std::vector<uint8_t>, outcome::result<ContentIdentifier>>> {
+    : public testing::TestWithParam<std::pair<
+          std::vector<uint8_t>, libp2p::outcome::result<ContentIdentifier>>> {
  public:
   void SetUp() {
     base_codec = std::make_shared<MultibaseCodecImpl>();
@@ -99,7 +98,7 @@ TEST_P(CidEncodeDecodeTest, DecodedMatchesOriginal) {
 }
 
 const std::vector<
-    std::pair<ContentIdentifier, outcome::result<std::vector<uint8_t>>>>
+    std::pair<ContentIdentifier, libp2p::outcome::result<std::vector<uint8_t>>>>
     encodeSuite{{ContentIdentifier(ContentIdentifier::Version::V0,
                                    MulticodecType::SHA1, ZERO_MULTIHASH),
                  ContentIdentifierCodec::EncodeError::INVALID_CONTENT_TYPE},
@@ -111,7 +110,7 @@ INSTANTIATE_TEST_CASE_P(EncodeTests, CidEncodeTest,
                         testing::ValuesIn(encodeSuite));
 
 const std::vector<
-    std::pair<std::vector<uint8_t>, outcome::result<ContentIdentifier>>>
+    std::pair<std::vector<uint8_t>, libp2p::outcome::result<ContentIdentifier>>>
     decodeSuite{{EXAMPLE_MULTIHASH.toBuffer(),
                  ContentIdentifier(ContentIdentifier::Version::V0,
                                    MulticodecType::DAG_PB, EXAMPLE_MULTIHASH)}};

--- a/test/libp2p/muxer/yamux/yamux_integration_test.cpp
+++ b/test/libp2p/muxer/yamux/yamux_integration_test.cpp
@@ -228,7 +228,7 @@ TEST_F(YamuxIntegrationTest, StreamFromServer) {
                        });
           });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();
@@ -274,7 +274,7 @@ TEST_F(YamuxIntegrationTest, StreamWrite) {
                                      });
                      });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();
@@ -315,7 +315,7 @@ TEST_F(YamuxIntegrationTest, StreamRead) {
                     });
               });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();
@@ -364,7 +364,7 @@ TEST_F(YamuxIntegrationTest, CloseForWrites) {
                 });
               });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();
@@ -400,7 +400,7 @@ TEST_F(YamuxIntegrationTest, CloseForReads) {
                     });
               });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();
@@ -457,7 +457,7 @@ TEST_F(YamuxIntegrationTest, CloseEntirely) {
                 });
               });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();
@@ -534,7 +534,7 @@ TEST_F(YamuxIntegrationTest, Reset) {
                            });
                      });
         });
-        return outcome::success();
+        return libp2p::outcome::success();
       });
 
   launchContext();

--- a/test/libp2p/protocol_muxer/multiselect_test.cpp
+++ b/test/libp2p/protocol_muxer/multiselect_test.cpp
@@ -108,21 +108,22 @@ class MultiselectTest : public ::testing::Test {
     conn->read(
         *read_msg, read_msg->size(),
         [conn, read_msg, expected_opening_msg,
-         next_step](const outcome::result<size_t> &read_bytes) {
+         next_step](const libp2p::outcome::result<size_t> &read_bytes) {
           EXPECT_TRUE(read_bytes) << read_bytes.error().message();
           EXPECT_EQ(*read_msg, expected_opening_msg);
 
           auto write_msg =
               std::make_shared<ByteArray>(0, expected_opening_msg.size());
 
-          conn->write(expected_opening_msg, expected_opening_msg.size(),
-                      [conn, expected_opening_msg, next_step](
-                          const outcome::result<size_t> &written_bytes_res) {
-                        EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
-                        EXPECT_EQ(written_bytes, expected_opening_msg.size());
+          conn->write(
+              expected_opening_msg, expected_opening_msg.size(),
+              [conn, expected_opening_msg, next_step](
+                  const libp2p::outcome::result<size_t> &written_bytes_res) {
+                EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
+                EXPECT_EQ(written_bytes, expected_opening_msg.size());
 
-                        next_step();
-                      });
+                next_step();
+              });
         });
   }
 
@@ -138,21 +139,22 @@ class MultiselectTest : public ::testing::Test {
     conn->write(
         expected_opening_msg, expected_opening_msg.size(),
         [conn, expected_opening_msg,
-         next_step](const outcome::result<size_t> &written_bytes_res) {
+         next_step](const libp2p::outcome::result<size_t> &written_bytes_res) {
           EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
           ASSERT_EQ(written_bytes, expected_opening_msg.size());
 
           auto read_msg =
               std::make_shared<ByteArray>(expected_opening_msg.size(), 0);
-          conn->read(*read_msg, expected_opening_msg.size(),
-                     [read_msg, expected_opening_msg, next_step](
-                         const outcome::result<size_t> &read_bytes_res) {
-                       EXPECT_OUTCOME_TRUE(read_bytes, read_bytes_res);
-                       EXPECT_EQ(read_bytes, expected_opening_msg.size());
+          conn->read(
+              *read_msg, expected_opening_msg.size(),
+              [read_msg, expected_opening_msg, next_step](
+                  const libp2p::outcome::result<size_t> &read_bytes_res) {
+                EXPECT_OUTCOME_TRUE(read_bytes, read_bytes_res);
+                EXPECT_EQ(read_bytes, expected_opening_msg.size());
 
-                       EXPECT_EQ(*read_msg, expected_opening_msg);
-                       next_step();
-                     });
+                EXPECT_EQ(*read_msg, expected_opening_msg);
+                next_step();
+              });
         });
   }
 
@@ -170,21 +172,22 @@ class MultiselectTest : public ::testing::Test {
     conn->read(
         *read_msg, expected_ls_msg.size(),
         [conn, read_msg, expected_ls_msg, protocols_msg,
-         next_step](const outcome::result<size_t> &read_bytes_res) {
+         next_step](const libp2p::outcome::result<size_t> &read_bytes_res) {
           EXPECT_TRUE(read_bytes_res) << read_bytes_res.error().message();
           EXPECT_OUTCOME_TRUE(read_bytes, read_bytes_res)
           EXPECT_EQ(read_bytes, expected_ls_msg.size());
 
           EXPECT_EQ(*read_msg, expected_ls_msg);
 
-          conn->write(protocols_msg, protocols_msg.size(),
-                      [conn, protocols_msg, next_step](
-                          const outcome::result<size_t> &written_bytes_res) {
-                        EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
-                        ASSERT_EQ(written_bytes, protocols_msg.size());
+          conn->write(
+              protocols_msg, protocols_msg.size(),
+              [conn, protocols_msg, next_step](
+                  const libp2p::outcome::result<size_t> &written_bytes_res) {
+                EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
+                ASSERT_EQ(written_bytes, protocols_msg.size());
 
-                        next_step();
-                      });
+                next_step();
+              });
         });
   }
 
@@ -198,19 +201,20 @@ class MultiselectTest : public ::testing::Test {
     conn->write(
         ls_msg, ls_msg.size(),
         [conn, ls_msg, protocols_msg,
-         next_step](const outcome::result<size_t> &written_bytes_res) {
+         next_step](const libp2p::outcome::result<size_t> &written_bytes_res) {
           EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
           EXPECT_EQ(written_bytes, ls_msg.size());
 
           auto read_msg = std::make_shared<ByteArray>(protocols_msg.size(), 0);
-          conn->read(*read_msg, read_msg->size(),
-                     [conn, read_msg, protocols_msg, next_step](
-                         const outcome::result<size_t> &read_bytes_res) {
-                       EXPECT_TRUE(read_bytes_res);
-                       EXPECT_EQ(*read_msg, protocols_msg);
+          conn->read(
+              *read_msg, read_msg->size(),
+              [conn, read_msg, protocols_msg, next_step](
+                  const libp2p::outcome::result<size_t> &read_bytes_res) {
+                EXPECT_TRUE(read_bytes_res);
+                EXPECT_EQ(*read_msg, protocols_msg);
 
-                       next_step();
-                     });
+                next_step();
+              });
         });
   }
 
@@ -249,22 +253,23 @@ class MultiselectTest : public ::testing::Test {
     auto na_msg = MessageManager::naMsg();
     auto protocol_msg = MessageManager::protocolMsg(proto_to_send);
 
-    conn->write(protocol_msg, protocol_msg.size(),
-                [conn, protocol_msg, na_msg,
-                 next_step](const outcome::result<size_t> written_bytes_res) {
-                  EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
-                  EXPECT_EQ(written_bytes, protocol_msg.size());
+    conn->write(
+        protocol_msg, protocol_msg.size(),
+        [conn, protocol_msg, na_msg,
+         next_step](const libp2p::outcome::result<size_t> written_bytes_res) {
+          EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
+          EXPECT_EQ(written_bytes, protocol_msg.size());
 
-                  auto read_msg = std::make_shared<ByteArray>(na_msg.size(), 0);
-                  conn->read(*read_msg, read_msg->size(),
-                             [conn, read_msg, na_msg, next_step](
-                                 const outcome::result<size_t> read_bytes_res) {
-                               EXPECT_TRUE(read_bytes_res);
-                               EXPECT_EQ(*read_msg, na_msg);
+          auto read_msg = std::make_shared<ByteArray>(na_msg.size(), 0);
+          conn->read(*read_msg, read_msg->size(),
+                     [conn, read_msg, na_msg, next_step](
+                         const libp2p::outcome::result<size_t> read_bytes_res) {
+                       EXPECT_TRUE(read_bytes_res);
+                       EXPECT_EQ(*read_msg, na_msg);
 
-                               next_step();
-                             });
-                });
+                       next_step();
+                     });
+        });
   }
 
   /**
@@ -279,14 +284,15 @@ class MultiselectTest : public ::testing::Test {
     auto read_msg = std::make_shared<ByteArray>(expected_proto_msg.size(), 0);
     conn->read(
         *read_msg, expected_proto_msg.size(),
-        [conn, read_msg,
-         expected_proto_msg](const outcome::result<size_t> &read_bytes_res) {
+        [conn, read_msg, expected_proto_msg](
+            const libp2p::outcome::result<size_t> &read_bytes_res) {
           EXPECT_TRUE(read_bytes_res);
           EXPECT_EQ(*read_msg, expected_proto_msg);
 
           conn->write(
               *read_msg, read_msg->size(),
-              [read_msg](const outcome::result<size_t> &written_bytes_res) {
+              [read_msg](
+                  const libp2p::outcome::result<size_t> &written_bytes_res) {
                 EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res);
                 EXPECT_EQ(written_bytes, read_msg->size());
               });
@@ -303,20 +309,20 @@ class MultiselectTest : public ::testing::Test {
 
     conn->write(
         expected_proto_msg, expected_proto_msg.size(),
-        [conn,
-         expected_proto_msg](const outcome::result<size_t> &written_bytes_res) {
+        [conn, expected_proto_msg](
+            const libp2p::outcome::result<size_t> &written_bytes_res) {
           EXPECT_OUTCOME_TRUE(written_bytes, written_bytes_res)
           EXPECT_EQ(written_bytes, expected_proto_msg.size());
 
           auto read_msg =
               std::make_shared<ByteArray>(expected_proto_msg.size(), 0);
-          conn->read(*read_msg, read_msg->size(),
-                     [conn, read_msg, expected_proto_msg](
-                         const outcome::result<size_t> &read_bytes_res) {
-                       EXPECT_TRUE(read_bytes_res)
-                           << read_bytes_res.error().message();
-                       EXPECT_EQ(*read_msg, expected_proto_msg);
-                     });
+          conn->read(
+              *read_msg, read_msg->size(),
+              [conn, read_msg, expected_proto_msg](
+                  const libp2p::outcome::result<size_t> &read_bytes_res) {
+                EXPECT_TRUE(read_bytes_res) << read_bytes_res.error().message();
+                EXPECT_EQ(*read_msg, expected_proto_msg);
+              });
         });
   }
 };
@@ -330,7 +336,8 @@ class MultiselectTest : public ::testing::Test {
 TEST_F(MultiselectTest, NegotiateAsInitiator) {
   auto negotiated = false;
   auto transport_listener = transport_->createListener(
-      [this](outcome::result<std::shared_ptr<CapableConnection>> rconn) {
+      [this](
+          libp2p::outcome::result<std::shared_ptr<CapableConnection>> rconn) {
         ASSERT_TRUE(rconn) << rconn.error().message();
         EXPECT_OUTCOME_TRUE(conn, rconn);
         // first, we expect an exchange of opening messages
@@ -350,13 +357,13 @@ TEST_F(MultiselectTest, NegotiateAsInitiator) {
   transport_->dial(
       testutil::randomPeerId(), ma,
       [this, &negotiated, &protocol_vec](
-          outcome::result<std::shared_ptr<CapableConnection>> rconn) {
+          libp2p::outcome::result<std::shared_ptr<CapableConnection>> rconn) {
         EXPECT_OUTCOME_TRUE(conn, rconn);
 
         multiselect_->selectOneOf(
             protocol_vec, conn, true,
             [this, &negotiated,
-             conn](const outcome::result<Protocol> &protocol_res) {
+             conn](const libp2p::outcome::result<Protocol> &protocol_res) {
               EXPECT_OUTCOME_TRUE(protocol, protocol_res);
               EXPECT_EQ(protocol, kDefaultEncryptionProtocol2);
               negotiated = true;
@@ -373,11 +380,13 @@ TEST_F(MultiselectTest, NegotiateAsListener) {
   std::vector<Protocol> protocol_vec{kDefaultEncryptionProtocol2};
   auto transport_listener = transport_->createListener(
       [this, &negotiated, &protocol_vec](
-          outcome::result<std::shared_ptr<CapableConnection>> rconn) mutable {
+          libp2p::outcome::result<std::shared_ptr<CapableConnection>>
+              rconn) mutable {
         EXPECT_OUTCOME_TRUE(conn, rconn);
         multiselect_->selectOneOf(
             protocol_vec, conn, false,
-            [this, &negotiated](const outcome::result<Protocol> &protocol_res) {
+            [this, &negotiated](
+                const libp2p::outcome::result<Protocol> &protocol_res) {
               EXPECT_OUTCOME_TRUE(protocol, protocol_res);
               EXPECT_EQ(protocol, kDefaultEncryptionProtocol2);
               negotiated = true;
@@ -390,7 +399,8 @@ TEST_F(MultiselectTest, NegotiateAsListener) {
 
   transport_->dial(
       testutil::randomPeerId(), ma,
-      [this](outcome::result<std::shared_ptr<CapableConnection>> rconn) {
+      [this](
+          libp2p::outcome::result<std::shared_ptr<CapableConnection>> rconn) {
         EXPECT_OUTCOME_TRUE(conn, rconn);
         // first, we expect an exchange of opening messages
         negotiationOpeningsListener(conn, [this, conn] {
@@ -428,12 +438,13 @@ TEST_F(MultiselectTest, NegotiateFailure) {
   std::vector<Protocol> protocol_vec{kDefaultEncryptionProtocol1};
   auto transport_listener = transport_->createListener(
       [this, &negotiated, &protocol_vec](
-          outcome::result<std::shared_ptr<CapableConnection>> rconn) mutable {
+          libp2p::outcome::result<std::shared_ptr<CapableConnection>>
+              rconn) mutable {
         EXPECT_OUTCOME_TRUE(conn, rconn);
 
         multiselect_->selectOneOf(
             protocol_vec, conn, true,
-            [](const outcome::result<Protocol> &protocol_result) {
+            [](const libp2p::outcome::result<Protocol> &protocol_result) {
               EXPECT_FALSE(protocol_result);
             });
         negotiated = true;
@@ -445,7 +456,8 @@ TEST_F(MultiselectTest, NegotiateFailure) {
 
   transport_->dial(
       testutil::randomPeerId(), ma,
-      [this](outcome::result<std::shared_ptr<CapableConnection>> rconn) {
+      [this](
+          libp2p::outcome::result<std::shared_ptr<CapableConnection>> rconn) {
         EXPECT_OUTCOME_TRUE(conn, rconn);
         negotiationOpeningsInitiator(conn, [this, conn] {
           negotiationProtocolNaInitiator(conn, kDefaultEncryptionProtocol1);
@@ -465,8 +477,9 @@ TEST_F(MultiselectTest, NegotiateFailure) {
 TEST_F(MultiselectTest, NoProtocols) {
   std::shared_ptr<RawConnection> conn = std::make_shared<RawConnectionMock>();
   std::vector<Protocol> empty_vec{};
-  multiselect_->selectOneOf(empty_vec, conn, true,
-                            [](const outcome::result<Protocol> &protocol_res) {
-                              EXPECT_FALSE(protocol_res);
-                            });
+  multiselect_->selectOneOf(
+      empty_vec, conn, true,
+      [](const libp2p::outcome::result<Protocol> &protocol_res) {
+        EXPECT_FALSE(protocol_res);
+      });
 }

--- a/test/libp2p/transport/tcp/tcp_integration_test.cpp
+++ b/test/libp2p/transport/tcp/tcp_integration_test.cpp
@@ -35,7 +35,7 @@ using ::testing::Return;
 
 namespace {
   std::shared_ptr<CapableConnection> expectConnectionValid(
-      outcome::result<std::shared_ptr<CapableConnection>> rconn) {
+      libp2p::outcome::result<std::shared_ptr<CapableConnection>> rconn) {
     EXPECT_TRUE(rconn) << rconn.error();
     auto conn = rconn.value();
 

--- a/test/libp2p/transport/upgrader_test.cpp
+++ b/test/libp2p/transport/upgrader_test.cpp
@@ -32,6 +32,9 @@ using testing::_;
 using testing::NiceMock;
 using testing::Return;
 
+using libp2p::outcome::failure;
+using libp2p::outcome::success;
+
 class UpgraderTest : public testing::Test {
  protected:
   void SetUp() override {
@@ -103,11 +106,11 @@ TEST_F(UpgraderTest, UpgradeSecureNotInitiator) {
       *multiselect_mock_,
       selectOneOf(gsl::span<const Protocol>(security_protos_),
                   std::static_pointer_cast<ReadWriter>(raw_conn_), false, _))
-      .WillOnce(Arg3CallbackWithArg(outcome::success(security_protos_[1])));
+      .WillOnce(Arg3CallbackWithArg(success(security_protos_[1])));
   EXPECT_CALL(
       *std::static_pointer_cast<SecurityAdaptorMock>(security_mocks_[1]),
       secureInbound(std::static_pointer_cast<RawConnection>(raw_conn_), _))
-      .WillOnce(Arg1CallbackWithArg(outcome::success(sec_conn_)));
+      .WillOnce(Arg1CallbackWithArg(success(sec_conn_)));
 
   upgrader_->upgradeToSecureInbound(
       raw_conn_, [this](auto &&upgraded_conn_res) {
@@ -122,7 +125,7 @@ TEST_F(UpgraderTest, UpgradeSecureFail) {
       *multiselect_mock_,
       selectOneOf(gsl::span<const Protocol>(security_protos_),
                   std::static_pointer_cast<ReadWriter>(raw_conn_), false, _))
-      .WillOnce(Arg3CallbackWithArg(outcome::failure(std::error_code())));
+      .WillOnce(Arg3CallbackWithArg(failure(std::error_code())));
 
   upgrader_->upgradeToSecureInbound(raw_conn_, [](auto &&upgraded_conn_res) {
     ASSERT_FALSE(upgraded_conn_res);
@@ -135,7 +138,7 @@ TEST_F(UpgraderTest, UpgradeMux) {
       *multiselect_mock_,
       selectOneOf(gsl::span<const Protocol>(muxer_protos_),
                   std::static_pointer_cast<ReadWriter>(sec_conn_), true, _))
-      .WillOnce(Arg3CallbackWithArg(outcome::success(muxer_protos_[0])));
+      .WillOnce(Arg3CallbackWithArg(success(muxer_protos_[0])));
   EXPECT_CALL(
       *std::static_pointer_cast<MuxerAdaptorMock>(muxer_mocks_[0]),
       muxConnection(std::static_pointer_cast<SecureConnection>(sec_conn_), _))
@@ -153,7 +156,7 @@ TEST_F(UpgraderTest, UpgradeMuxFail) {
       *multiselect_mock_,
       selectOneOf(gsl::span<const Protocol>(muxer_protos_),
                   std::static_pointer_cast<ReadWriter>(sec_conn_), true, _))
-      .WillOnce(Arg3CallbackWithArg(outcome::failure(std::error_code())));
+      .WillOnce(Arg3CallbackWithArg(failure(std::error_code())));
 
   upgrader_->upgradeToMuxed(sec_conn_, [](auto &&upgraded_conn_res) {
     ASSERT_FALSE(upgraded_conn_res);


### PR DESCRIPTION
Libp2p's outcome::result interferes with Kagome's outcome::result definitions.
Need to hide it into namespace.