### PR TITLE
fix spdlog config

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -12,5 +12,5 @@ hunter_config(GSL
 hunter_config(
     spdlog
     URL https://github.com/gabime/spdlog/archive/v1.4.2.zip
-    SHA1 f71ea50c7c50ecb7ca0502983ce4542aa6dba0c4
+    SHA1 4b10e9aa17f7d568e24f464b48358ab46cb6f39c
 )

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -11,6 +11,6 @@ hunter_config(GSL
 
 hunter_config(
     spdlog
-    URL https://github.com/gabime/spdlog/archive/v1.x.zip
-    SHA1 086e9f8e3708024d5765fa5f94695819b223be23
+    URL https://github.com/gabime/spdlog/archive/v1.4.2.zip
+    SHA1 f71ea50c7c50ecb7ca0502983ce4542aa6dba0c4
 )


### PR DESCRIPTION
spdlog version wasn't bound to a tag, but to a branch.
each time a new commit appeared, hash was changed.
this change makes it stable.