### PR TITLE
add p2p_default_host to p2p

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(p2p
     libp2p.cpp
     )
 target_link_libraries(p2p INTERFACE
+    p2p_default_host
     p2p_default_network
     )
 libp2p_install(p2p)


### PR DESCRIPTION
p2p target of libp2p should contain p2p_default_host as well as p2p_default_network, for now host his missing. 
This fix adds p2p_default_host to p2p target.