### PR TITLE
remove build and test steps for di and hat-trie

### DIFF
--- a/cmake/boost_di.cmake
+++ b/cmake/boost_di.cmake
@@ -23,11 +23,13 @@ set_package_properties(boost_di
     )
 
 externalproject_add(boost_di
-    GIT_REPOSITORY  ${GIT_URL}
-    GIT_TAG         ${GIT_TAG}
-    GIT_SHALLOW     1
+    GIT_REPOSITORY ${GIT_URL}
+    GIT_TAG ${GIT_TAG}
+    GIT_SHALLOW 1
     TLS_VERIFY true
     INSTALL_COMMAND "" # remove install step
+    BUILD_COMMAND "" # remove build step
+    TEST_COMMAND "" # remove test step
     )
 
 add_dependencies(di boost_di)

--- a/cmake/hat-trie.cmake
+++ b/cmake/hat-trie.cmake
@@ -23,11 +23,13 @@ set_package_properties(hat-trie-imp
     )
 
 externalproject_add(hat-trie-imp
-    GIT_REPOSITORY  ${GIT_URL}
-    GIT_TAG         ${GIT_TAG}
-    GIT_SHALLOW     1
+    GIT_REPOSITORY ${GIT_URL}
+    GIT_TAG ${GIT_TAG}
+    GIT_SHALLOW 1
     TLS_VERIFY true
     INSTALL_COMMAND "" # remove install step
+    BUILD_COMMAND "" # remove build step
+    TEST_COMMAND "" # remove test step
     )
 
 add_dependencies(hat_trie hat-trie-imp)


### PR DESCRIPTION
di and hat trie don't need build step since they are header only.
test step is not required.