### PR TITLE
Transform KeyGenerator to CryptoProvider

### DIFF
--- a/include/libp2p/crypto/crypto_provider.hpp
+++ b/include/libp2p/crypto/crypto_provider.hpp
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef LIBP2P_CRYPTO_KEY_GENERATOR_HPP
-#define LIBP2P_CRYPTO_KEY_GENERATOR_HPP
+#ifndef LIBP2P_CRYPTO_PROVIDER_HPP
+#define LIBP2P_CRYPTO_PROVIDER_HPP
 
 #include <boost/filesystem.hpp>
+#include <gsl/span>
 #include <libp2p/crypto/common.hpp>
 #include <libp2p/crypto/key.hpp>
 #include <libp2p/outcome/outcome.hpp>
@@ -14,13 +15,14 @@
 
 namespace libp2p::crypto {
   /**
-   * @class KeyGenerator provides interface for key generation functions
+   * @class CryptoProvider provides interface for key generation, singing,
+   * signature verification functions for private/public key cryptography
    */
-  class KeyGenerator {
+  class CryptoProvider {
    public:
     using Buffer = std::vector<uint8_t>;
 
-    virtual ~KeyGenerator() = default;
+    virtual ~CryptoProvider() = default;
 
     /**
      * @brief generates new key pair of specified type
@@ -36,9 +38,30 @@ namespace libp2p::crypto {
      */
     virtual outcome::result<PublicKey> derivePublicKey(
         const PrivateKey &private_key) const = 0;
+
     /**
-     * Generate an ephemeral public key and return a function that will compute
-     * the shared secret key
+     * @brief signs a given message using passed private key
+     * @param message bytes to be signed
+     * @param private_key a part of keypair used for signature generation
+     * @return signature bytes
+     */
+    virtual outcome::result<Buffer> sign(
+        gsl::span<uint8_t> message, const PrivateKey &private_key) const = 0;
+
+    /**
+     * @brief verifies validness of the signature for a given message and public
+     * key
+     * @param message that was signed
+     * @param signature to be validated
+     * @param public_key to validate against
+     * @return true - if the signature matches the message and the public key
+     */
+    virtual outcome::result<bool> verify(gsl::span<uint8_t> message,
+                                         gsl::span<uint8_t> signature,
+                                         const PublicKey &public_key) const = 0;
+    /**
+     * Generate an ephemeral public key and return a function that will
+     * compute the shared secret key
      * @param curve to be used in this ECDH
      * @return ephemeral key pair
      */
@@ -59,4 +82,4 @@ namespace libp2p::crypto {
 
 }  // namespace libp2p::crypto
 
-#endif  // LIBP2P_CRYPTO_KEY_GENERATOR_HPP
+#endif  // LIBP2P_CRYPTO_PROVIDER_HPP

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -3,26 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef LIBP2P_CRYPTO_KEY_GENERATOR_KEY_GENERATOR_IMPL_HPP
-#define LIBP2P_CRYPTO_KEY_GENERATOR_KEY_GENERATOR_IMPL_HPP
+#ifndef LIBP2P_CRYPTO_PROVIDER_CRYPTO_PROVIDER_IMPL_HPP
+#define LIBP2P_CRYPTO_PROVIDER_CRYPTO_PROVIDER_IMPL_HPP
 
-#include <libp2p/crypto/key_generator.hpp>
+#include <libp2p/crypto/crypto_provider.hpp>
 
 namespace libp2p::crypto {
   namespace random {
     class CSPRNG;
   }
 
-  class KeyGeneratorImpl : public KeyGenerator {
+  class CryptoProviderImpl : public CryptoProvider {
    public:
-    ~KeyGeneratorImpl() override = default;
+    ~CryptoProviderImpl() override = default;
 
-    explicit KeyGeneratorImpl(random::CSPRNG &random_provider);
+    explicit CryptoProviderImpl(random::CSPRNG &random_provider);
 
     outcome::result<KeyPair> generateKeys(Key::Type key_type) const override;
 
     outcome::result<PublicKey> derivePublicKey(
         const PrivateKey &private_key) const override;
+
+    outcome::result<Buffer> sign(gsl::span<uint8_t> message,
+                                 const PrivateKey &private_key) const override;
+
+    outcome::result<bool> verify(gsl::span<uint8_t> message,
+                                 gsl::span<uint8_t> signature,
+                                 const PublicKey &public_key) const override;
 
     outcome::result<EphemeralKeyPair> generateEphemeralKeyPair(
         common::CurveType curve) const override;
@@ -43,4 +50,4 @@ namespace libp2p::crypto {
   };
 }  // namespace libp2p::crypto
 
-#endif  // LIBP2P_CRYPTO_KEY_GENERATOR_KEY_GENERATOR_IMPL_HPP
+#endif  // LIBP2P_CRYPTO_PROVIDER_CRYPTO_PROVIDER_IMPL_HPP

--- a/include/libp2p/crypto/error.hpp
+++ b/include/libp2p/crypto/error.hpp
@@ -10,9 +10,11 @@
 
 namespace libp2p::crypto {
   enum class CryptoProviderError {
-    INVALID_KEY_TYPE = 1,   ///< failed to unmarshal key type, wrong value
-    UNKNOWN_KEY_TYPE,       ///< failed to unmarshal key
-    FAILED_UNMARSHAL_DATA,  ///< protobuf error, failed to unmarshal data
+    INVALID_KEY_TYPE = 1,         ///< failed to unmarshal key type, wrong value
+    UNKNOWN_KEY_TYPE,             ///< failed to unmarshal key
+    FAILED_UNMARSHAL_DATA,        ///< protobuf error, failed to unmarshal data
+    SIGNATURE_GENERATION_FAILED,  ///< general signature creation failure
+    SIGNATURE_VERIFICATION_FAILED,  ///< general signature verification failure
   };
 
   enum class OpenSslError {

--- a/include/libp2p/crypto/key_validator/key_validator_impl.hpp
+++ b/include/libp2p/crypto/key_validator/key_validator_impl.hpp
@@ -8,13 +8,13 @@
 
 #include <memory>
 
-#include <libp2p/crypto/key_generator.hpp>
+#include <libp2p/crypto/crypto_provider.hpp>
 #include <libp2p/crypto/key_validator.hpp>
 
 namespace libp2p::crypto::validator {
   class KeyValidatorImpl : public KeyValidator {
    public:
-    explicit KeyValidatorImpl(std::shared_ptr<KeyGenerator> key_generator);
+    explicit KeyValidatorImpl(std::shared_ptr<CryptoProvider> key_generator);
 
     outcome::result<void> validate(const PrivateKey &key) const override;
 
@@ -32,7 +32,7 @@ namespace libp2p::crypto::validator {
     outcome::result<void> validateSecp256k1(const PrivateKey &key) const;
     outcome::result<void> validateSecp256k1(const PublicKey &key) const;
 
-    std::shared_ptr<KeyGenerator> key_generator_;
+    std::shared_ptr<CryptoProvider> key_generator_;
   };
 }  // namespace libp2p::crypto::validator
 

--- a/include/libp2p/crypto/key_validator/key_validator_impl.hpp
+++ b/include/libp2p/crypto/key_validator/key_validator_impl.hpp
@@ -14,7 +14,7 @@
 namespace libp2p::crypto::validator {
   class KeyValidatorImpl : public KeyValidator {
    public:
-    explicit KeyValidatorImpl(std::shared_ptr<CryptoProvider> key_generator);
+    explicit KeyValidatorImpl(std::shared_ptr<CryptoProvider> crypto_provider);
 
     outcome::result<void> validate(const PrivateKey &key) const override;
 
@@ -32,7 +32,7 @@ namespace libp2p::crypto::validator {
     outcome::result<void> validateSecp256k1(const PrivateKey &key) const;
     outcome::result<void> validateSecp256k1(const PublicKey &key) const;
 
-    std::shared_ptr<CryptoProvider> key_generator_;
+    std::shared_ptr<CryptoProvider> crypto_provider_;
   };
 }  // namespace libp2p::crypto::validator
 

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -224,17 +224,20 @@ namespace libp2p::injector {
     using namespace boost;  // NOLINT
 
     auto csprng = std::make_shared<crypto::random::BoostRandomGenerator>();
-    auto gen = std::make_shared<crypto::CryptoProviderImpl>(*csprng);
-    auto validator = std::make_shared<crypto::validator::KeyValidatorImpl>(gen);
+    auto crypto_provider =
+        std::make_shared<crypto::CryptoProviderImpl>(*csprng);
+    auto validator =
+        std::make_shared<crypto::validator::KeyValidatorImpl>(crypto_provider);
 
     // assume no error here. otherwise... just blow up executable
-    auto keypair = gen->generateKeys(crypto::Key::Type::Ed25519).value();
+    auto keypair =
+        crypto_provider->generateKeys(crypto::Key::Type::Ed25519).value();
 
     // clang-format off
     return di::make_injector(
         di::bind<crypto::KeyPair>().template to(std::move(keypair)),
         di::bind<crypto::random::CSPRNG>().template to(std::move(csprng)),
-        di::bind<crypto::CryptoProvider>().template to(std::move(gen)),
+        di::bind<crypto::CryptoProvider>().template to(std::move(crypto_provider)),
         di::bind<crypto::marshaller::KeyMarshaller>().template to<crypto::marshaller::KeyMarshallerImpl>(),
         di::bind<peer::IdentityManager>().template to<peer::IdentityManagerImpl>(),
         di::bind<crypto::validator::KeyValidator>().template to<crypto::validator::KeyValidatorImpl>(),

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -9,7 +9,7 @@
 #include <boost/di.hpp>
 
 // implementations
-#include <libp2p/crypto/key_generator/key_generator_impl.hpp>
+#include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
@@ -224,7 +224,7 @@ namespace libp2p::injector {
     using namespace boost;  // NOLINT
 
     auto csprng = std::make_shared<crypto::random::BoostRandomGenerator>();
-    auto gen = std::make_shared<crypto::KeyGeneratorImpl>(*csprng);
+    auto gen = std::make_shared<crypto::CryptoProviderImpl>(*csprng);
     auto validator = std::make_shared<crypto::validator::KeyValidatorImpl>(gen);
 
     // assume no error here. otherwise... just blow up executable
@@ -234,7 +234,7 @@ namespace libp2p::injector {
     return di::make_injector(
         di::bind<crypto::KeyPair>().template to(std::move(keypair)),
         di::bind<crypto::random::CSPRNG>().template to(std::move(csprng)),
-        di::bind<crypto::KeyGenerator>().template to(std::move(gen)),
+        di::bind<crypto::CryptoProvider>().template to(std::move(gen)),
         di::bind<crypto::marshaller::KeyMarshaller>().template to<crypto::marshaller::KeyMarshallerImpl>(),
         di::bind<peer::IdentityManager>().template to<peer::IdentityManagerImpl>(),
         di::bind<crypto::validator::KeyValidator>().template to<crypto::validator::KeyValidatorImpl>(),

--- a/include/libp2p/network/default_network.hpp
+++ b/include/libp2p/network/default_network.hpp
@@ -7,7 +7,7 @@
 #define LIBP2P_DEFAULT_NETWORK_HPP
 
 // implementations
-#include <libp2p/crypto/key_generator/key_generator_impl.hpp>
+#include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
 #include <libp2p/muxer/yamux.hpp>
@@ -23,4 +23,4 @@
 #include <libp2p/transport/impl/upgrader_impl.hpp>
 #include <libp2p/transport/tcp.hpp>
 
-#endif //LIBP2P_DEFAULT_NETWORK_HPP
+#endif  // LIBP2P_DEFAULT_NETWORK_HPP

--- a/include/libp2p/peer/impl/identity_manager_impl.hpp
+++ b/include/libp2p/peer/impl/identity_manager_impl.hpp
@@ -6,10 +6,10 @@
 #ifndef LIBP2P_IDENTITY_MANAGER_IMPL_HPP
 #define LIBP2P_IDENTITY_MANAGER_IMPL_HPP
 
-#include <libp2p/crypto/key_generator.hpp>
+#include <libp2p/crypto/crypto_provider.hpp>
+#include <libp2p/crypto/key_marshaller.hpp>
 #include <libp2p/peer/identity_manager.hpp>
 #include <libp2p/peer/key_repository.hpp>
-#include <libp2p/crypto/key_marshaller.hpp>
 
 namespace libp2p::peer {
   class IdentityManagerImpl : public IdentityManager {

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 add_subdirectory(aes_provider)
 add_subdirectory(hmac_provider)
-add_subdirectory(key_generator)
+add_subdirectory(crypto_provider)
 add_subdirectory(key_marshaller)
 add_subdirectory(key_validator)
 add_subdirectory(protobuf)

--- a/src/crypto/crypto_provider/CMakeLists.txt
+++ b/src/crypto/crypto_provider/CMakeLists.txt
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-libp2p_add_library(p2p_key_generator
-    key_generator_impl.cpp
+libp2p_add_library(p2p_crypto_provider
+        crypto_provider_impl.cpp
     )
 
-target_link_libraries(p2p_key_generator
+target_link_libraries(p2p_crypto_provider
     p2p_crypto_error
     p2p_random_generator
     OpenSSL::Crypto

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -28,8 +28,8 @@ namespace libp2p::crypto {
   void CryptoProviderImpl::initialize() {
     constexpr size_t kSeedBytesCount = 128 * 4;  // ripple uses such number
     auto bytes = random_provider_.randomBytes(kSeedBytesCount);
-    // seeding random generator is required prior to calling RSA_generate_key
-    // NOLINTNEXTLINE
+    // seeding random crypto_provider is required prior to calling
+    // RSA_generate_key NOLINTNEXTLINE
     RAND_seed(static_cast<const void *>(bytes.data()), bytes.size());
   }
 

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -371,13 +371,13 @@ namespace libp2p::crypto {
 
   outcome::result<Buffer> CryptoProviderImpl::sign(
       gsl::span<uint8_t> message, const PrivateKey &private_key) const {
-    return KeyGeneratorError::KEY_GENERATION_FAILED;
+    return CryptoProviderError::SIGNATURE_GENERATION_FAILED;
   }
 
   outcome::result<bool> CryptoProviderImpl::verify(
       gsl::span<uint8_t> message, gsl::span<uint8_t> signature,
       const PublicKey &public_key) const {
-    return KeyGeneratorError::KEY_GENERATION_FAILED;
+    return CryptoProviderError::SIGNATURE_VERIFICATION_FAILED;
   }
 
   outcome::result<EphemeralKeyPair>

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <libp2p/crypto/key_generator/key_generator_impl.hpp>
+#include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
 
 #include <exception>
 #include <iostream>
@@ -20,12 +20,12 @@
 #include <libp2p/crypto/random_generator.hpp>
 
 namespace libp2p::crypto {
-  KeyGeneratorImpl::KeyGeneratorImpl(random::CSPRNG &random_provider)
+  CryptoProviderImpl::CryptoProviderImpl(random::CSPRNG &random_provider)
       : random_provider_(random_provider) {
     initialize();
   }
 
-  void KeyGeneratorImpl::initialize() {
+  void CryptoProviderImpl::initialize() {
     constexpr size_t kSeedBytesCount = 128 * 4;  // ripple uses such number
     auto bytes = random_provider_.randomBytes(kSeedBytesCount);
     // seeding random generator is required prior to calling RSA_generate_key
@@ -177,7 +177,7 @@ namespace libp2p::crypto {
      *  https://www.openssl.org/docs/man1.0.2/man3/i2d_RSAPrivateKey.html
      *  d2i_RSAPrivateKey(), i2d_RSAPrivateKey() decode and encode a PKCS#1
      */
-    outcome::result<std::pair<KeyGenerator::Buffer, KeyGenerator::Buffer>>
+    outcome::result<std::pair<CryptoProvider::Buffer, CryptoProvider::Buffer>>
     generateRsaKeys(int bits) {
       int ret = 0;
       RSA *rsa = nullptr;
@@ -215,7 +215,7 @@ namespace libp2p::crypto {
     }
   }  // namespace detail
 
-  outcome::result<KeyPair> KeyGeneratorImpl::generateKeys(
+  outcome::result<KeyPair> CryptoProviderImpl::generateKeys(
       Key::Type key_type) const {
     switch (key_type) {
       case Key::Type::RSA:
@@ -234,7 +234,7 @@ namespace libp2p::crypto {
 
   /// previous implementation is commented - it can be used as a hint when
   /// implementing a new version of the method
-  //  outcome::result<KeyPair> KeyGeneratorImpl::generateRsa(
+  //  outcome::result<KeyPair> CryptoProviderImpl::generateRsa(
   //      common::RSAKeyType bits_option) const {
   //    BOOST_ASSERT_MSG(false, "not implemented");
   //
@@ -261,7 +261,7 @@ namespace libp2p::crypto {
   //                   {{key_type, std::move(keys.second)}}};
   //  }
 
-  outcome::result<KeyPair> KeyGeneratorImpl::generateEd25519() const {
+  outcome::result<KeyPair> CryptoProviderImpl::generateEd25519() const {
     EVP_PKEY *pkey = nullptr;
     EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, nullptr);
 
@@ -293,7 +293,7 @@ namespace libp2p::crypto {
                    {{Key::Type::Ed25519, std::move(private_key_bytes)}}};
   }
 
-  outcome::result<KeyPair> KeyGeneratorImpl::generateSecp256k1() const {
+  outcome::result<KeyPair> CryptoProviderImpl::generateSecp256k1() const {
     EC_KEY *key = EC_KEY_new();
     if (nullptr == key) {
       return KeyGeneratorError::KEY_GENERATION_FAILED;
@@ -352,7 +352,7 @@ namespace libp2p::crypto {
                    {{Key::Type::Secp256k1, std::move(private_bytes)}}};
   }
 
-  outcome::result<PublicKey> KeyGeneratorImpl::derivePublicKey(
+  outcome::result<PublicKey> CryptoProviderImpl::derivePublicKey(
       const PrivateKey &private_key) const {
     switch (private_key.type) {
       case Key::Type::RSA:
@@ -369,13 +369,24 @@ namespace libp2p::crypto {
     return KeyGeneratorError::UNSUPPORTED_KEY_TYPE;
   }
 
-  outcome::result<EphemeralKeyPair> KeyGeneratorImpl::generateEphemeralKeyPair(
-      common::CurveType curve) const {
+  outcome::result<Buffer> CryptoProviderImpl::sign(
+      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+    return KeyGeneratorError::KEY_GENERATION_FAILED;
+  }
+
+  outcome::result<bool> CryptoProviderImpl::verify(
+      gsl::span<uint8_t> message, gsl::span<uint8_t> signature,
+      const PublicKey &public_key) const {
+    return KeyGeneratorError::KEY_GENERATION_FAILED;
+  }
+
+  outcome::result<EphemeralKeyPair>
+  CryptoProviderImpl::generateEphemeralKeyPair(common::CurveType curve) const {
     // TODO(yuraz): pre-140 implement
     return KeyGeneratorError::KEY_GENERATION_FAILED;
   }
 
-  std::vector<StretchedKey> KeyGeneratorImpl::stretchKey(
+  std::vector<StretchedKey> CryptoProviderImpl::stretchKey(
       common::CipherType cipher_type, common::HashType hash_type,
       const Buffer &secret) const {
     // TODO(yuraz): pre-140 implement

--- a/src/crypto/error.cpp
+++ b/src/crypto/error.cpp
@@ -103,7 +103,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::crypto, KeyGeneratorError, e) {
     case KeyGeneratorError::INTERNAL_ERROR:
       return "internal error happened";
   }
-  return "unknown KeyGenerator error";
+  return "unknown key generation error";
 }
 
 OUTCOME_CPP_DEFINE_CATEGORY(libp2p::crypto, KeyValidatorError, e) {

--- a/src/crypto/error.cpp
+++ b/src/crypto/error.cpp
@@ -14,6 +14,10 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::crypto, CryptoProviderError, e) {
       return "failed to unmarshal key";
     case CryptoProviderError::FAILED_UNMARSHAL_DATA:
       return "google protobuf error, failed to unmarshal data";
+    case CryptoProviderError::SIGNATURE_GENERATION_FAILED:
+      return "error while signing data";
+    case CryptoProviderError::SIGNATURE_VERIFICATION_FAILED:
+      return "error while verifying signature";
   }
   return "unknown CryptoProviderError code";
 }

--- a/src/crypto/key_marshaller/key_marshaller_impl.cpp
+++ b/src/crypto/key_marshaller/key_marshaller_impl.cpp
@@ -5,9 +5,9 @@
 
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 
-#include <libp2p/crypto/common.hpp>
-#include <libp2p/crypto/key_generator.hpp>
 #include <generated/crypto/protobuf/keys.pb.h>
+#include <libp2p/crypto/common.hpp>
+#include <libp2p/crypto/crypto_provider.hpp>
 
 namespace libp2p::crypto::marshaller {
   namespace {

--- a/src/crypto/key_validator/CMakeLists.txt
+++ b/src/crypto/key_validator/CMakeLists.txt
@@ -7,7 +7,7 @@ libp2p_add_library(p2p_key_validator
     key_validator_impl.cpp
     )
 target_link_libraries(p2p_key_validator
-    p2p_key_generator
+    p2p_crypto_provider
     p2p_crypto_error
     OpenSSL::Crypto
     )

--- a/src/crypto/key_validator/key_validator_impl.cpp
+++ b/src/crypto/key_validator/key_validator_impl.cpp
@@ -31,7 +31,7 @@ namespace libp2p::crypto::validator {
   }  // namespace
 
   KeyValidatorImpl::KeyValidatorImpl(
-      std::shared_ptr<KeyGenerator> key_generator)
+      std::shared_ptr<CryptoProvider> key_generator)
       : key_generator_{std::move(key_generator)} {}
 
   outcome::result<void> KeyValidatorImpl::validate(

--- a/src/crypto/key_validator/key_validator_impl.cpp
+++ b/src/crypto/key_validator/key_validator_impl.cpp
@@ -31,8 +31,8 @@ namespace libp2p::crypto::validator {
   }  // namespace
 
   KeyValidatorImpl::KeyValidatorImpl(
-      std::shared_ptr<CryptoProvider> key_generator)
-      : key_generator_{std::move(key_generator)} {}
+      std::shared_ptr<CryptoProvider> crypto_provider)
+      : crypto_provider_{std::move(crypto_provider)} {}
 
   outcome::result<void> KeyValidatorImpl::validate(
       const PrivateKey &key) const {
@@ -82,7 +82,7 @@ namespace libp2p::crypto::validator {
     OUTCOME_TRY(validate(keys.privateKey));
     OUTCOME_TRY(validate(keys.publicKey));
 
-    OUTCOME_TRY(public_key, key_generator_->derivePublicKey(keys.privateKey));
+    OUTCOME_TRY(public_key, crypto_provider_->derivePublicKey(keys.privateKey));
     if (public_key != keys.publicKey) {
       return KeyValidatorError::KEYS_DONT_MATCH;
     }

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(p2p_default_network
     p2p_router
     p2p_multiselect
     p2p_random_generator
-    p2p_key_generator
+    p2p_crypto_provider
     p2p_key_validator
     p2p_key_marshaller
     )

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -21,7 +21,7 @@ Peer::Peer(Peer::Duration timeout)
       echo_{std::make_shared<Echo>()},
       random_provider_{std::make_shared<BoostRandomGenerator>()},
       key_generator_{
-          std::make_shared<crypto::KeyGeneratorImpl>(*random_provider_)} {
+          std::make_shared<crypto::CryptoProviderImpl>(*random_provider_)} {
   EXPECT_OUTCOME_TRUE_MSG(
       keys, key_generator_->generateKeys(crypto::Key::Type::Ed25519),
       "failed to generate keys");
@@ -85,7 +85,7 @@ void Peer::wait() {
 
 Peer::sptr<host::BasicHost> Peer::makeHost(crypto::KeyPair keyPair) {
   auto key_generator =
-      std::make_shared<crypto::KeyGeneratorImpl>(*random_provider_);
+      std::make_shared<crypto::CryptoProviderImpl>(*random_provider_);
 
   auto key_validator = std::make_shared<crypto::validator::KeyValidatorImpl>(
       std::move(key_generator));

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -20,10 +20,10 @@ Peer::Peer(Peer::Duration timeout)
       context_{std::make_shared<Context>()},
       echo_{std::make_shared<Echo>()},
       random_provider_{std::make_shared<BoostRandomGenerator>()},
-      key_generator_{
+      crypto_provider_{
           std::make_shared<crypto::CryptoProviderImpl>(*random_provider_)} {
   EXPECT_OUTCOME_TRUE_MSG(
-      keys, key_generator_->generateKeys(crypto::Key::Type::Ed25519),
+      keys, crypto_provider_->generateKeys(crypto::Key::Type::Ed25519),
       "failed to generate keys");
 
   host_ = makeHost(std::move(keys));
@@ -84,11 +84,11 @@ void Peer::wait() {
 }
 
 Peer::sptr<host::BasicHost> Peer::makeHost(crypto::KeyPair keyPair) {
-  auto key_generator =
+  auto crypto_provider =
       std::make_shared<crypto::CryptoProviderImpl>(*random_provider_);
 
   auto key_validator = std::make_shared<crypto::validator::KeyValidatorImpl>(
-      std::move(key_generator));
+      std::move(crypto_provider));
 
   auto key_marshaller = std::make_shared<crypto::marshaller::KeyMarshallerImpl>(
       std::move(key_validator));

--- a/test/acceptance/p2p/host/peer/test_peer.hpp
+++ b/test/acceptance/p2p/host/peer/test_peer.hpp
@@ -33,7 +33,7 @@ class Peer {
   using Host = libp2p::Host;
   using Echo = libp2p::protocol::Echo;
   using BoostRandomGenerator = libp2p::crypto::random::BoostRandomGenerator;
-  using KeyGenerator = libp2p::crypto::KeyGenerator;
+  using KeyGenerator = libp2p::crypto::CryptoProvider;
 
   using Context = boost::asio::io_context;
 

--- a/test/acceptance/p2p/host/peer/test_peer.hpp
+++ b/test/acceptance/p2p/host/peer/test_peer.hpp
@@ -33,7 +33,7 @@ class Peer {
   using Host = libp2p::Host;
   using Echo = libp2p::protocol::Echo;
   using BoostRandomGenerator = libp2p::crypto::random::BoostRandomGenerator;
-  using KeyGenerator = libp2p::crypto::CryptoProvider;
+  using CryptoProvider = libp2p::crypto::CryptoProvider;
 
   using Context = boost::asio::io_context;
 
@@ -78,7 +78,7 @@ class Peer {
   sptr<Host> host_;                             ///< host
   sptr<Echo> echo_;                             ///< echo protocol
   sptr<BoostRandomGenerator> random_provider_;  ///< random provider
-  sptr<KeyGenerator> key_generator_;            ///< key generator
+  sptr<CryptoProvider> crypto_provider_;        ///< crypto provider
 };
 
 #endif  // LIBP2P_HOST_TEST_PEER_HPP

--- a/test/libp2p/crypto/CMakeLists.txt
+++ b/test/libp2p/crypto/CMakeLists.txt
@@ -43,7 +43,7 @@ addtest(keygen_test
     key_generator_test.cpp
     )
 target_link_libraries(keygen_test
-    p2p_key_generator
+    p2p_crypto_provider
     )
 
 addtest(key_validator_test

--- a/test/libp2p/crypto/key_generator_test.cpp
+++ b/test/libp2p/crypto/key_generator_test.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "libp2p/crypto/key_generator/key_generator_impl.hpp"
+#include "libp2p/crypto/crypto_provider/crypto_provider_impl.hpp"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -14,15 +14,15 @@
 #include "testutil/outcome.hpp"
 
 using libp2p::common::ByteArray;
+using libp2p::crypto::CryptoProviderImpl;
 using libp2p::crypto::Key;
 using libp2p::crypto::KeyGeneratorError;
-using libp2p::crypto::KeyGeneratorImpl;
 using libp2p::crypto::random::BoostRandomGenerator;
 
 class KeyGeneratorTest : public ::testing::TestWithParam<Key::Type> {
  protected:
   BoostRandomGenerator random_;
-  KeyGeneratorImpl keygen_{random_};
+  CryptoProviderImpl keygen_{random_};
 };
 
 /**
@@ -86,7 +86,7 @@ class KeyLengthTest
           std::tuple<Key::Type, const uint32_t, const uint32_t>> {
  protected:
   BoostRandomGenerator random_;
-  KeyGeneratorImpl keygen_{random_};
+  CryptoProviderImpl keygen_{random_};
 };
 
 INSTANTIATE_TEST_CASE_P(

--- a/test/libp2p/crypto/key_generator_test.cpp
+++ b/test/libp2p/crypto/key_generator_test.cpp
@@ -22,7 +22,7 @@ using libp2p::crypto::random::BoostRandomGenerator;
 class KeyGeneratorTest : public ::testing::TestWithParam<Key::Type> {
  protected:
   BoostRandomGenerator random_;
-  CryptoProviderImpl keygen_{random_};
+  CryptoProviderImpl crypto_provider_{random_};
 };
 
 /**
@@ -36,7 +36,7 @@ TEST_P(KeyGeneratorTest, GenerateKeyPairSuccess) {
     return;
   }
 
-  EXPECT_OUTCOME_TRUE_2(val, keygen_.generateKeys(key_type))
+  EXPECT_OUTCOME_TRUE_2(val, crypto_provider_.generateKeys(key_type))
   ASSERT_EQ(val.privateKey.type, key_type);
   ASSERT_EQ(val.publicKey.type, key_type);
 }
@@ -52,8 +52,8 @@ TEST_P(KeyGeneratorTest, TwoKeysAreDifferent) {
     return;
   }
 
-  EXPECT_OUTCOME_TRUE_2(val1, keygen_.generateKeys(key_type));
-  EXPECT_OUTCOME_TRUE_2(val2, keygen_.generateKeys(key_type));
+  EXPECT_OUTCOME_TRUE_2(val1, crypto_provider_.generateKeys(key_type));
+  EXPECT_OUTCOME_TRUE_2(val2, crypto_provider_.generateKeys(key_type));
   ASSERT_NE(val1.privateKey.data, val2.privateKey.data);
   ASSERT_NE(val1.publicKey.data, val2.privateKey.data);
 }
@@ -71,8 +71,9 @@ TEST_P(KeyGeneratorTest, DerivePublicKeySuccess) {
     return;
   }
 
-  EXPECT_OUTCOME_TRUE_2(keys, keygen_.generateKeys(key_type));
-  EXPECT_OUTCOME_TRUE_2(derived, keygen_.derivePublicKey(keys.privateKey));
+  EXPECT_OUTCOME_TRUE_2(keys, crypto_provider_.generateKeys(key_type));
+  EXPECT_OUTCOME_TRUE_2(derived,
+                        crypto_provider_.derivePublicKey(keys.privateKey));
   ASSERT_EQ(derived.type, key_type);
   ASSERT_EQ(keys.publicKey.data, derived.data);
 }

--- a/test/libp2p/crypto/key_validator_test.cpp
+++ b/test/libp2p/crypto/key_validator_test.cpp
@@ -30,10 +30,10 @@ using libp2p::crypto::validator::KeyValidatorImpl;
 
 struct BaseKeyTest {
   BoostRandomGenerator random;
-  std::shared_ptr<CryptoProvider> generator =
+  std::shared_ptr<CryptoProvider> crypto_provider =
       std::make_shared<CryptoProviderImpl>(random);
   std::shared_ptr<KeyValidator> validator =
-      std::make_shared<KeyValidatorImpl>(generator);
+      std::make_shared<KeyValidatorImpl>(crypto_provider);
 };
 
 class GeneratedKeysTest : public BaseKeyTest,
@@ -55,7 +55,7 @@ TEST_P(GeneratedKeysTest, GeneratedKeysAreValid) {
     // RSA generation is not implemented yet
     return;
   }
-  EXPECT_OUTCOME_TRUE(key_pair, generator->generateKeys(key_type))
+  EXPECT_OUTCOME_TRUE(key_pair, crypto_provider->generateKeys(key_type))
   EXPECT_OUTCOME_TRUE_1(validator->validate(key_pair.publicKey))
   EXPECT_OUTCOME_TRUE_1(validator->validate(key_pair.privateKey))
   EXPECT_OUTCOME_TRUE_1(validator->validate(key_pair))
@@ -99,7 +99,7 @@ TEST_P(GeneratedKeysTest, InvalidPublicKeyInvalidatesPair) {
     return;
   }
 
-  EXPECT_OUTCOME_TRUE(key_pair, generator->generateKeys(key_type))
+  EXPECT_OUTCOME_TRUE(key_pair, crypto_provider->generateKeys(key_type))
   auto public_key = PublicKey{{key_type, random.randomBytes(64)}};
   EXPECT_OUTCOME_FALSE_1(validator->validate(public_key))
   auto invalid_pair = KeyPair{public_key, key_pair.privateKey};
@@ -128,7 +128,7 @@ TEST_P(RandomKeyTest, Every32byteIsValidPrivateKey) {
   auto sequence = random.randomBytes(32);
   auto private_key = PrivateKey{{key_type, sequence}};
   EXPECT_OUTCOME_TRUE_1(validator->validate(private_key))
-  EXPECT_OUTCOME_TRUE_1(generator->derivePublicKey(private_key))
+  EXPECT_OUTCOME_TRUE_1(crypto_provider->derivePublicKey(private_key))
 }
 
 INSTANTIATE_TEST_CASE_P(RandomSequencesCases, RandomKeyTest,

--- a/test/libp2p/crypto/key_validator_test.cpp
+++ b/test/libp2p/crypto/key_validator_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "libp2p/crypto/key_generator/key_generator_impl.hpp"
+#include "libp2p/crypto/crypto_provider/crypto_provider_impl.hpp"
 #include "libp2p/crypto/key_validator/key_validator_impl.hpp"
 #include "libp2p/crypto/random_generator/boost_generator.hpp"
 #include "testutil/outcome.hpp"
@@ -18,9 +18,9 @@ using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::Return;
 
+using libp2p::crypto::CryptoProvider;
+using libp2p::crypto::CryptoProviderImpl;
 using libp2p::crypto::Key;
-using libp2p::crypto::KeyGenerator;
-using libp2p::crypto::KeyGeneratorImpl;
 using libp2p::crypto::KeyPair;
 using libp2p::crypto::PrivateKey;
 using libp2p::crypto::PublicKey;
@@ -30,8 +30,8 @@ using libp2p::crypto::validator::KeyValidatorImpl;
 
 struct BaseKeyTest {
   BoostRandomGenerator random;
-  std::shared_ptr<KeyGenerator> generator =
-      std::make_shared<KeyGeneratorImpl>(random);
+  std::shared_ptr<CryptoProvider> generator =
+      std::make_shared<CryptoProviderImpl>(random);
   std::shared_ptr<KeyValidator> validator =
       std::make_shared<KeyValidatorImpl>(generator);
 };

--- a/test/libp2p/peer/CMakeLists.txt
+++ b/test/libp2p/peer/CMakeLists.txt
@@ -8,7 +8,7 @@ addtest(peer_id_test
     )
 target_link_libraries(peer_id_test
     p2p_peer_id
-    p2p_key_generator
+    p2p_crypto_provider
     p2p_key_marshaller
     p2p_random_generator
     p2p_key_validator

--- a/test/libp2p/security/CMakeLists.txt
+++ b/test/libp2p/security/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(plaintext_adaptor_test
     p2p_multihash
     p2p_multiaddress
     p2p_random_generator
-    p2p_key_generator
+    p2p_crypto_provider
     p2p_key_marshaller
     )
 


### PR DESCRIPTION
Add `sign` and `verify` methods required by private/public key cryptography to interfaces.
And change the meaning of KeyGenerator to CryptoProvider.

Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>