### PR TITLE
Implement Ed25519 crypto provider

### DIFF
--- a/include/libp2p/common/literals.hpp
+++ b/include/libp2p/common/literals.hpp
@@ -23,8 +23,10 @@ namespace libp2p {
   }
 
   namespace common {
+    /// Only for type casting in tests. No hash is computed
     Hash256 operator""_hash256(const char *c, size_t s);
 
+    /// Only for type casting in tests. No hash is computed
     Hash512 operator""_hash512(const char *c, size_t s);
 
     std::vector<uint8_t> operator""_v(const char *c, size_t s);

--- a/include/libp2p/common/literals.hpp
+++ b/include/libp2p/common/literals.hpp
@@ -25,6 +25,8 @@ namespace libp2p {
   namespace common {
     Hash256 operator""_hash256(const char *c, size_t s);
 
+    Hash512 operator""_hash512(const char *c, size_t s);
+
     std::vector<uint8_t> operator""_v(const char *c, size_t s);
 
     std::vector<uint8_t> operator""_unhex(const char *c, size_t s);

--- a/include/libp2p/common/types.hpp
+++ b/include/libp2p/common/types.hpp
@@ -26,12 +26,9 @@ namespace libp2p::common {
     c.push_back(g);
   }
 
-  /**
-   * Hash256 as a sequence of 32 bytes
-   * and
-   * Hash512 as a sequence of 64 bytes
-   */
+  /// Hash256 as a sequence of 32 bytes
   using Hash256 = std::array<uint8_t, 32u>;
+  /// Hash512 as a sequence of 64 bytes
   using Hash512 = std::array<uint8_t, 64u>;
 }  // namespace libp2p::common
 

--- a/include/libp2p/common/types.hpp
+++ b/include/libp2p/common/types.hpp
@@ -22,14 +22,17 @@ namespace libp2p::common {
   }
 
   template <typename Collection>
-  void append(Collection& c, char g) {
+  void append(Collection &c, char g) {
     c.push_back(g);
   }
 
   /**
    * Hash256 as a sequence of 32 bytes
+   * and
+   * Hash512 as a sequence of 64 bytes
    */
   using Hash256 = std::array<uint8_t, 32u>;
+  using Hash512 = std::array<uint8_t, 64u>;
 }  // namespace libp2p::common
 
 #endif  // LIBP2P_P2P_COMMON_TYPES_HPP

--- a/include/libp2p/crypto/common_functions.hpp
+++ b/include/libp2p/crypto/common_functions.hpp
@@ -38,6 +38,15 @@ namespace libp2p::crypto {
   outcome::result<std::shared_ptr<EVP_PKEY>> NewEvpPkeyFromBytes(
       int type, gsl::span<const uint8_t> key_bytes, ReaderFunc *reader);
 
+  /*
+   * The following template instantiation serves for both -
+   * EVP_PKEY_new_raw_private_key and EVP_PKEY_new_raw_public_key
+   * since their types are identical.
+   */
+  extern template outcome::result<std::shared_ptr<EVP_PKEY>>
+  NewEvpPkeyFromBytes(int, gsl::span<const uint8_t>,
+                      decltype(EVP_PKEY_new_raw_public_key) *);
+
 }  // namespace libp2p::crypto
 
 #endif  // LIBP2P_COMMON_FUNCTIONS_HPP

--- a/include/libp2p/crypto/common_functions.hpp
+++ b/include/libp2p/crypto/common_functions.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIBP2P_COMMON_FUNCTIONS_HPP
+#define LIBP2P_COMMON_FUNCTIONS_HPP
+
+#include <memory>
+
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+#include <gsl/span>
+#include <libp2p/outcome/outcome.hpp>
+
+namespace libp2p::crypto {
+  /**
+   * Initializes EC_KEY structure with private and public key from private key
+   * bytes
+   * @param nid - curve group identifier for the key, ex. NID_secp256k1
+   * @param private_key - private key bytes
+   * @return shared pointer to EC_KEY with overridden destructor
+   */
+  outcome::result<std::shared_ptr<EC_KEY>> EcKeyFromPrivateKeyBytes(
+      int nid, gsl::span<const uint8_t> private_key);
+
+  /**
+   * Initializes EVP_PKEY structure from private or public key bytes
+   * @tparam ReaderFunc type of restore method. ex. EVP_PKEY_new_raw_private_key
+   * or EVP_PKEY_new_raw_public_key
+   * @param type - key type (almost the same as nid for ECC). ex.
+   * EVP_PKEY_ED25519
+   * @param key_bytes - raw representation of the source key
+   * @param reader - pointer to a function of type ReaderFunc
+   * @return shared pointer to EVP_PKEY with overridden destructor
+   */
+  template <typename ReaderFunc>
+  outcome::result<std::shared_ptr<EVP_PKEY>> NewEvpPkeyFromBytes(
+      int type, gsl::span<const uint8_t> key_bytes, ReaderFunc *reader);
+
+}  // namespace libp2p::crypto
+
+#endif  // LIBP2P_COMMON_FUNCTIONS_HPP

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -12,12 +12,17 @@ namespace libp2p::crypto {
   namespace random {
     class CSPRNG;
   }
+  namespace ed25519 {
+    class Ed25519Provider;
+  }
 
   class CryptoProviderImpl : public CryptoProvider {
    public:
     ~CryptoProviderImpl() override = default;
 
-    explicit CryptoProviderImpl(random::CSPRNG &random_provider);
+    explicit CryptoProviderImpl(
+        std::shared_ptr<random::CSPRNG> random_provider,
+        std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider);
 
     outcome::result<KeyPair> generateKeys(Key::Type key_type) const override;
 
@@ -50,7 +55,8 @@ namespace libp2p::crypto {
     outcome::result<KeyPair> generateEcdsa256WithCurve(Key::Type key_type,
                                                        int curve_nid) const;
 
-    random::CSPRNG &random_provider_;  ///< random bytes generator
+    std::shared_ptr<random::CSPRNG> random_provider_;
+    std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider_;
   };
 }  // namespace libp2p::crypto
 

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -52,6 +52,13 @@ namespace libp2p::crypto {
     outcome::result<KeyPair> generateSecp256k1() const;
     outcome::result<KeyPair> generateEcdsa() const;
 
+    outcome::result<PublicKey> deriveEd25519(const PrivateKey &key) const;
+    outcome::result<Buffer> signEd25519(gsl::span<uint8_t> message,
+                                        const PrivateKey &private_key) const;
+    outcome::result<bool> verifyEd25519(gsl::span<uint8_t> message,
+                                        gsl::span<uint8_t> signature,
+                                        const PublicKey &public_key) const;
+
     outcome::result<KeyPair> generateEcdsa256WithCurve(Key::Type key_type,
                                                        int curve_nid) const;
 

--- a/include/libp2p/crypto/ed25519_provider.hpp
+++ b/include/libp2p/crypto/ed25519_provider.hpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIBP2P_ED25519_PROVIDER_HPP
+#define LIBP2P_ED25519_PROVIDER_HPP
+
+#include <array>
+
+#include <gsl/span>
+#include <libp2p/outcome/outcome.hpp>
+
+namespace libp2p::crypto::ed25519 {
+
+  using PrivateKey = std::array<uint8_t, 32u>;
+  using PublicKey = std::array<uint8_t, 32u>;
+  struct Keypair {
+    PrivateKey private_key;
+    PublicKey public_key;
+  };
+  using Signature = std::array<uint8_t, 64u>;
+
+  class Ed25519Provider {
+   public:
+    /**
+     * Generate keypair
+     * @return a struct with private and public keys as byte arrays
+     */
+    virtual outcome::result<Keypair> generate() const = 0;
+
+    /**
+     * Derive public key from a given private key
+     * @param private_key - bytes representation of a private key
+     * @return public key as byte array
+     */
+    virtual outcome::result<PublicKey> derive(
+        const PrivateKey &private_key) const = 0;
+
+    /**
+     * Sign a message using private key. Message digest calculated as SHA512
+     * @param message - the source message as bytes sequence
+     * @param private_key - private key bytes
+     * @return signature as bytes sequence
+     */
+    virtual outcome::result<Signature> sign(
+        gsl::span<uint8_t> message, const PrivateKey &private_key) const = 0;
+
+    /**
+     * Verify signature of a message against a given public key
+     * @param message - the source message as bytes sequence
+     * @param signature - signature bytes
+     * @param public_key - public key bytes
+     * @return - true when signature is valid, false - otherwise
+     */
+    virtual outcome::result<bool> verify(gsl::span<uint8_t> message,
+                                         const Signature &signature,
+                                         const PublicKey &public_key) const = 0;
+
+    virtual ~Ed25519Provider() = default;
+  };
+
+}  // namespace libp2p::crypto::ed25519
+
+#endif  // LIBP2P_ED25519_PROVIDER_HPP

--- a/include/libp2p/crypto/ed25519_provider.hpp
+++ b/include/libp2p/crypto/ed25519_provider.hpp
@@ -21,6 +21,9 @@ namespace libp2p::crypto::ed25519 {
   };
   using Signature = std::array<uint8_t, 64u>;
 
+  /**
+   * An interface for Ed25519 private/public key cryptography operations.
+   */
   class Ed25519Provider {
    public:
     /**

--- a/include/libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp
+++ b/include/libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIBP2P_ED25519_PROVIDER_ED25519_PROVIDER_IMPL_HPP
+#define LIBP2P_ED25519_PROVIDER_ED25519_PROVIDER_IMPL_HPP
+
+#include <libp2p/crypto/ed25519_provider.hpp>
+
+namespace libp2p::crypto::ed25519 {
+
+  class Ed25519ProviderImpl : public Ed25519Provider {
+   public:
+    outcome::result<Keypair> generate() const override;
+
+    outcome::result<PublicKey> derive(
+        const PrivateKey &private_key) const override;
+
+    outcome::result<Signature> sign(
+        gsl::span<uint8_t> message,
+        const PrivateKey &private_key) const override;
+
+    outcome::result<bool> verify(gsl::span<uint8_t> message,
+                                 const Signature &signature,
+                                 const PublicKey &public_key) const override;
+  };
+
+}  // namespace libp2p::crypto::ed25519
+
+#endif  // LIBP2P_ED25519_PROVIDER_ED25519_PROVIDER_IMPL_HPP

--- a/include/libp2p/crypto/sha/sha512.hpp
+++ b/include/libp2p/crypto/sha/sha512.hpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIBP2P_SHA512_HPP
+#define LIBP2P_SHA512_HPP
+
+#include <string_view>
+
+#include <gsl/span>
+#include <libp2p/common/types.hpp>
+
+namespace libp2p::crypto {
+  /**
+   * Take a SHA-512 hash from string
+   * @param input to be hashed
+   * @return hashed bytes
+   */
+  libp2p::common::Hash512 sha512(std::string_view input);
+
+  /**
+   * Take a SHA-512 hash from bytes
+   * @param input to be hashed
+   * @return hashed bytes
+   */
+  libp2p::common::Hash512 sha512(gsl::span<const uint8_t> input);
+}  // namespace libp2p::crypto
+
+#endif  // LIBP2P_SHA512_HPP

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -10,6 +10,7 @@
 
 // implementations
 #include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
+#include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
@@ -224,8 +225,10 @@ namespace libp2p::injector {
     using namespace boost;  // NOLINT
 
     auto csprng = std::make_shared<crypto::random::BoostRandomGenerator>();
+    auto ed25519_provider =
+        std::make_shared<crypto::ed25519::Ed25519ProviderImpl>();
     auto crypto_provider =
-        std::make_shared<crypto::CryptoProviderImpl>(*csprng);
+        std::make_shared<crypto::CryptoProviderImpl>(csprng, ed25519_provider);
     auto validator =
         std::make_shared<crypto::validator::KeyValidatorImpl>(crypto_provider);
 
@@ -237,7 +240,8 @@ namespace libp2p::injector {
     return di::make_injector(
         di::bind<crypto::KeyPair>().template to(std::move(keypair)),
         di::bind<crypto::random::CSPRNG>().template to(std::move(csprng)),
-        di::bind<crypto::CryptoProvider>().template to(std::move(crypto_provider)),
+        di::bind<crypto::ed25519::Ed25519Provider>().template to(std::move(ed25519_provider)),
+        di::bind<crypto::CryptoProvider>().template to<crypto::CryptoProviderImpl>(),
         di::bind<crypto::marshaller::KeyMarshaller>().template to<crypto::marshaller::KeyMarshallerImpl>(),
         di::bind<peer::IdentityManager>().template to<peer::IdentityManagerImpl>(),
         di::bind<crypto::validator::KeyValidator>().template to<crypto::validator::KeyValidatorImpl>(),

--- a/src/common/literals.cpp
+++ b/src/common/literals.cpp
@@ -18,6 +18,12 @@ namespace libp2p::common {
     return hash;
   }
 
+  libp2p::common::Hash512 operator""_hash512(const char *c, size_t s) {
+    libp2p::common::Hash512 hash{};
+    std::copy_n(c, std::min(s, 64ul), hash.rbegin());
+    return hash;
+  }
+
   std::vector<uint8_t> operator""_v(const char *c, size_t s) {
     std::vector<uint8_t> chars(c, c + s);  // NOLINT
     return chars;

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -4,14 +4,14 @@
 #
 
 add_subdirectory(aes_provider)
-add_subdirectory(hmac_provider)
 add_subdirectory(crypto_provider)
+add_subdirectory(ed25519_provider)
+add_subdirectory(hmac_provider)
 add_subdirectory(key_marshaller)
 add_subdirectory(key_validator)
 add_subdirectory(protobuf)
 add_subdirectory(random_generator)
 add_subdirectory(sha)
-add_subdirectory(ed25519_provider)
 
 libp2p_add_library(p2p_crypto_error
     error.cpp

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(key_validator)
 add_subdirectory(protobuf)
 add_subdirectory(random_generator)
 add_subdirectory(sha)
+add_subdirectory(ed25519_provider)
 
 libp2p_add_library(p2p_crypto_error
     error.cpp
@@ -24,4 +25,11 @@ libp2p_add_library(p2p_crypto_key
     )
 target_link_libraries(p2p_crypto_key
     Boost::boost
+    )
+
+libp2p_add_library(p2p_crypto_common
+    common_functions.cpp
+    )
+target_link_libraries(p2p_crypto_common
+    p2p_crypto_error
     )

--- a/src/crypto/common_functions.cpp
+++ b/src/crypto/common_functions.cpp
@@ -23,7 +23,11 @@ namespace libp2p::crypto {
     }
     auto free_curve = gsl::finally([curve] { EC_GROUP_free(curve); });
 
-    // allocate the key
+    /*
+     * Allocate the key.
+     * Here we use shared pointer instead of gsl::finally since this is going to
+     * be used as a return value in case of success.
+     */
     std::shared_ptr<EC_KEY> key{EC_KEY_new(), EC_KEY_free};
     if (nullptr == key.get()) {
       return FAILED;

--- a/src/crypto/common_functions.cpp
+++ b/src/crypto/common_functions.cpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <libp2p/crypto/common_functions.hpp>
+
+#include <gsl/gsl_util>
+#include <libp2p/crypto/error.hpp>
+
+namespace libp2p::crypto {
+
+  outcome::result<std::shared_ptr<EC_KEY>> EcKeyFromPrivateKeyBytes(
+      int nid, gsl::span<const uint8_t> private_key) {
+    auto FAILED = KeyGeneratorError::INTERNAL_ERROR;
+
+    // try initialize requested curve group
+    EC_GROUP *curve = EC_GROUP_new_by_curve_name(nid);
+    if (nullptr == curve) {
+      return CryptoProviderError::UNKNOWN_KEY_TYPE;
+    }
+    auto free_curve = gsl::finally([curve] { EC_GROUP_free(curve); });
+
+    // allocate the key
+    std::shared_ptr<EC_KEY> key{EC_KEY_new(), EC_KEY_free};
+    if (nullptr == key.get()) {
+      return FAILED;
+    }
+
+    // associate the curve with the key
+    if (1 != EC_KEY_set_group(key.get(), curve)) {
+      return FAILED;
+    }
+
+    // turn private key bytes into big number
+    BIGNUM *private_bignum{
+        BN_bin2bn(private_key.data(), private_key.size(), nullptr)};
+    if (nullptr == private_bignum) {
+      return FAILED;
+    }
+    auto free_private_bignum =
+        gsl::finally([private_bignum] { BN_free(private_bignum); });
+
+    // set private key to the resulting key structure
+    if (1 != EC_KEY_set_private_key(key.get(), private_bignum)) {
+      return FAILED;
+    }
+
+    // EC_KEY that has a private key but do not has public key assumed invalid
+    // thus we are generating its public key part
+    EC_POINT *public_key_point{EC_POINT_new(curve)};
+    if (nullptr == public_key_point) {
+      return FAILED;
+    }
+    auto free_public_key_point =
+        gsl::finally([public_key_point] { EC_POINT_free(public_key_point); });
+
+    // derive the public key
+    if (1
+        != EC_POINT_mul(curve, public_key_point, private_bignum, nullptr,
+                        nullptr, nullptr)) {
+      return FAILED;
+    }
+
+    // check the public key
+    if (1 != EC_POINT_is_on_curve(curve, public_key_point, nullptr)) {
+      return KeyValidatorError::INVALID_PUBLIC_KEY;
+    }
+
+    // set public key to the resulting key structure
+    if (1 != EC_KEY_set_public_key(key.get(), public_key_point)) {
+      return FAILED;
+    }
+
+    // final check
+    if (1 != EC_KEY_check_key(key.get())) {
+      return KeyValidatorError::INVALID_PRIVATE_KEY;
+    }
+
+    return key;
+  }
+
+  template <typename ReaderFunc>
+  outcome::result<std::shared_ptr<EVP_PKEY>> NewEvpPkeyFromBytes(
+      int type, gsl::span<const uint8_t> key_bytes, ReaderFunc *reader) {
+    std::shared_ptr<EVP_PKEY> key{
+        reader(type, nullptr, key_bytes.data(), key_bytes.size()),
+        EVP_PKEY_free};
+
+    if (nullptr == key.get()) {
+      return KeyGeneratorError::INTERNAL_ERROR;
+    }
+    return key;
+  }
+
+}  // namespace libp2p::crypto

--- a/src/crypto/common_functions.cpp
+++ b/src/crypto/common_functions.cpp
@@ -29,7 +29,7 @@ namespace libp2p::crypto {
      * be used as a return value in case of success.
      */
     std::shared_ptr<EC_KEY> key{EC_KEY_new(), EC_KEY_free};
-    if (nullptr == key.get()) {
+    if (nullptr == key) {
       return FAILED;
     }
 
@@ -93,7 +93,7 @@ namespace libp2p::crypto {
         reader(type, nullptr, key_bytes.data(), key_bytes.size()),
         EVP_PKEY_free};
 
-    if (nullptr == key.get()) {
+    if (nullptr == key) {
       return KeyGeneratorError::INTERNAL_ERROR;
     }
     return key;

--- a/src/crypto/common_functions.cpp
+++ b/src/crypto/common_functions.cpp
@@ -5,6 +5,8 @@
 
 #include <libp2p/crypto/common_functions.hpp>
 
+#include <iostream>
+
 #include <gsl/gsl_util>
 #include <libp2p/crypto/error.hpp>
 
@@ -92,5 +94,8 @@ namespace libp2p::crypto {
     }
     return key;
   }
+
+  template outcome::result<std::shared_ptr<EVP_PKEY>> NewEvpPkeyFromBytes(
+      int, gsl::span<const uint8_t>, decltype(EVP_PKEY_new_raw_public_key) *);
 
 }  // namespace libp2p::crypto

--- a/src/crypto/crypto_provider/CMakeLists.txt
+++ b/src/crypto/crypto_provider/CMakeLists.txt
@@ -9,6 +9,7 @@ libp2p_add_library(p2p_crypto_provider
 
 target_link_libraries(p2p_crypto_provider
     p2p_crypto_error
+    p2p_ed25519_provider
     p2p_random_generator
     OpenSSL::Crypto
     Boost::filesystem

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -219,7 +219,7 @@ namespace libp2p::crypto {
     switch (key_type) {
       case Key::Type::RSA:
         // TODO(akvinikym) 01.10.19 PRE-314: implement
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return KeyGeneratorError::KEY_GENERATION_FAILED;
       case Key::Type::Ed25519:
         return generateEd25519();
       case Key::Type::Secp256k1:
@@ -369,13 +369,13 @@ namespace libp2p::crypto {
       gsl::span<uint8_t> message, const PrivateKey &private_key) const {
     switch (private_key.type) {
       case Key::Type::RSA:
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return CryptoProviderError::SIGNATURE_GENERATION_FAILED;
       case Key::Type::Ed25519:
         return signEd25519(message, private_key);
       case Key::Type::Secp256k1:
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return CryptoProviderError::SIGNATURE_GENERATION_FAILED;
       case Key::Type::ECDSA:
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return CryptoProviderError::SIGNATURE_GENERATION_FAILED;
       case Key::Type::UNSPECIFIED:
         return KeyGeneratorError::WRONG_KEY_TYPE;
       default:
@@ -396,13 +396,13 @@ namespace libp2p::crypto {
       const PublicKey &public_key) const {
     switch (public_key.type) {
       case Key::Type::RSA:
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return CryptoProviderError::SIGNATURE_VERIFICATION_FAILED;
       case Key::Type::Ed25519:
         return verifyEd25519(message, signature, public_key);
       case Key::Type::Secp256k1:
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return CryptoProviderError::SIGNATURE_VERIFICATION_FAILED;
       case Key::Type::ECDSA:
-        BOOST_ASSERT_MSG(false, "not implemented");
+        return CryptoProviderError::SIGNATURE_VERIFICATION_FAILED;
       case Key::Type::UNSPECIFIED:
         return KeyGeneratorError::WRONG_KEY_TYPE;
       default:

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -16,18 +16,22 @@
 #include <gsl/gsl_util>
 #include <gsl/pointers>
 #include <gsl/span>
+#include <libp2p/crypto/ed25519_provider.hpp>
 #include <libp2p/crypto/error.hpp>
 #include <libp2p/crypto/random_generator.hpp>
 
 namespace libp2p::crypto {
-  CryptoProviderImpl::CryptoProviderImpl(random::CSPRNG &random_provider)
-      : random_provider_(random_provider) {
+  CryptoProviderImpl::CryptoProviderImpl(
+      std::shared_ptr<random::CSPRNG> random_provider,
+      std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider)
+      : random_provider_{std::move(random_provider)},
+        ed25519_provider_{std::move(ed25519_provider)} {
     initialize();
   }
 
   void CryptoProviderImpl::initialize() {
     constexpr size_t kSeedBytesCount = 128 * 4;  // ripple uses such number
-    auto bytes = random_provider_.randomBytes(kSeedBytesCount);
+    auto bytes = random_provider_->randomBytes(kSeedBytesCount);
     // seeding random crypto_provider is required prior to calling
     // RSA_generate_key NOLINTNEXTLINE
     RAND_seed(static_cast<const void *>(bytes.data()), bytes.size());

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -97,20 +97,6 @@ namespace libp2p::crypto {
       return PublicKey{{key.type, std::move(public_bytes)}};
     }
 
-    outcome::result<PublicKey> deriveEd25519(const PrivateKey &key) {
-      EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(
-          EVP_PKEY_ED25519, nullptr, key.data.data(), key.data.size());
-      if (nullptr == pkey) {
-        return KeyGeneratorError::KEY_DERIVATION_FAILED;
-      }
-      auto free_pkey = gsl::finally([pkey] { EVP_PKEY_free(pkey); });
-
-      OUTCOME_TRY(public_buffer,
-                  getEvpPkeyRawBytes(pkey, EVP_PKEY_get_raw_public_key));
-
-      return PublicKey{{key.type, std::move(public_buffer)}};
-    }
-
     outcome::result<PublicKey> deriveEcdsa256WithCurve(const PrivateKey &key,
                                                        int curve_nid) {
       // put private key bytes to internal representation
@@ -275,35 +261,14 @@ namespace libp2p::crypto {
   //  }
 
   outcome::result<KeyPair> CryptoProviderImpl::generateEd25519() const {
-    EVP_PKEY *pkey = nullptr;
-    EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, nullptr);
+    OUTCOME_TRY(ed, ed25519_provider_->generate());
 
-    auto cleanup = gsl::finally([&]() {
-      if (pkey != nullptr) {
-        EVP_PKEY_free(pkey);
-      }
-      if (pctx != nullptr) {
-        EVP_PKEY_CTX_free(pctx);
-      }
-    });
-
-    auto ret = EVP_PKEY_keygen_init(pctx);
-    if (ret != 1) {
-      return KeyGeneratorError::KEY_GENERATION_FAILED;
-    }
-
-    ret = EVP_PKEY_keygen(pctx, &pkey);
-    if (ret != 1) {
-      return KeyGeneratorError::KEY_GENERATION_FAILED;
-    }
-
-    OUTCOME_TRY(private_key_bytes,
-                detail::getEvpPkeyRawBytes(pkey, EVP_PKEY_get_raw_private_key));
-    OUTCOME_TRY(public_key_bytes,
-                detail::getEvpPkeyRawBytes(pkey, EVP_PKEY_get_raw_public_key));
-
-    return KeyPair{{{Key::Type::Ed25519, std::move(public_key_bytes)}},
-                   {{Key::Type::Ed25519, std::move(private_key_bytes)}}};
+    auto &&pub = ed.public_key;
+    auto &&priv = ed.private_key;
+    return KeyPair{.publicKey = {{.type = Key::Type::Ed25519,
+                                  .data = {pub.begin(), pub.end()}}},
+                   .privateKey = {{.type = Key::Type::Ed25519,
+                                   .data = {priv.begin(), priv.end()}}}};
   }
 
   outcome::result<KeyPair> CryptoProviderImpl::generateSecp256k1() const {
@@ -380,7 +345,7 @@ namespace libp2p::crypto {
       case Key::Type::RSA:
         return detail::deriveRsa(private_key);
       case Key::Type::Ed25519:
-        return detail::deriveEd25519(private_key);
+        return deriveEd25519(private_key);
       case Key::Type::Secp256k1:
         return detail::deriveSecp256k1(private_key);
       case Key::Type::ECDSA:
@@ -391,15 +356,71 @@ namespace libp2p::crypto {
     return KeyGeneratorError::UNSUPPORTED_KEY_TYPE;
   }
 
+  outcome::result<PublicKey> CryptoProviderImpl::deriveEd25519(
+      const PrivateKey &key) const {
+    ed25519::PrivateKey private_key;
+    std::copy_n(key.data.begin(), private_key.size(), private_key.begin());
+    OUTCOME_TRY(ed_pub, ed25519_provider_->derive(private_key));
+
+    return PublicKey{{key.type, {ed_pub.begin(), ed_pub.end()}}};
+  }
+
   outcome::result<Buffer> CryptoProviderImpl::sign(
       gsl::span<uint8_t> message, const PrivateKey &private_key) const {
-    return CryptoProviderError::SIGNATURE_GENERATION_FAILED;
+    switch (private_key.type) {
+      case Key::Type::RSA:
+        BOOST_ASSERT_MSG(false, "not implemented");
+      case Key::Type::Ed25519:
+        return signEd25519(message, private_key);
+      case Key::Type::Secp256k1:
+        BOOST_ASSERT_MSG(false, "not implemented");
+      case Key::Type::ECDSA:
+        BOOST_ASSERT_MSG(false, "not implemented");
+      case Key::Type::UNSPECIFIED:
+        return KeyGeneratorError::WRONG_KEY_TYPE;
+      default:
+        return CryptoProviderError::SIGNATURE_GENERATION_FAILED;
+    }
+  }
+
+  outcome::result<Buffer> CryptoProviderImpl::signEd25519(
+      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+    ed25519::PrivateKey priv_key;
+    std::copy_n(private_key.data.begin(), priv_key.size(), priv_key.begin());
+    OUTCOME_TRY(signature, ed25519_provider_->sign(message, priv_key));
+    return {signature.begin(), signature.end()};
   }
 
   outcome::result<bool> CryptoProviderImpl::verify(
       gsl::span<uint8_t> message, gsl::span<uint8_t> signature,
       const PublicKey &public_key) const {
-    return CryptoProviderError::SIGNATURE_VERIFICATION_FAILED;
+    switch (public_key.type) {
+      case Key::Type::RSA:
+        BOOST_ASSERT_MSG(false, "not implemented");
+      case Key::Type::Ed25519:
+        return verifyEd25519(message, signature, public_key);
+      case Key::Type::Secp256k1:
+        BOOST_ASSERT_MSG(false, "not implemented");
+      case Key::Type::ECDSA:
+        BOOST_ASSERT_MSG(false, "not implemented");
+      case Key::Type::UNSPECIFIED:
+        return KeyGeneratorError::WRONG_KEY_TYPE;
+      default:
+        return CryptoProviderError::SIGNATURE_VERIFICATION_FAILED;
+    }
+  }
+
+  outcome::result<bool> CryptoProviderImpl::verifyEd25519(
+      gsl::span<uint8_t> message, gsl::span<uint8_t> signature,
+      const PublicKey &public_key) const {
+    ed25519::PrivateKey ed_pub;
+    std::copy_n(public_key.data.begin(), ed_pub.size(), ed_pub.begin());
+
+    ed25519::Signature ed_sig;
+    std::copy_n(signature.begin(), ed_sig.size(), ed_sig.begin());
+
+    OUTCOME_TRY(result, ed25519_provider_->verify(message, ed_sig, ed_pub));
+    return result;
   }
 
   outcome::result<EphemeralKeyPair>

--- a/src/crypto/ed25519_provider/CMakeLists.txt
+++ b/src/crypto/ed25519_provider/CMakeLists.txt
@@ -4,11 +4,12 @@
 #
 
 libp2p_add_library(p2p_ed25519_provider
-        ed25519_provider_impl.cpp
-        )
+    ed25519_provider_impl.cpp
+    )
 
 target_link_libraries(p2p_ed25519_provider
-        p2p_crypto_error
-        p2p_common_functions
-        OpenSSL::Crypto
-        )
+    p2p_crypto_error
+    p2p_crypto_common
+    p2p_sha
+    OpenSSL::Crypto
+    )

--- a/src/crypto/ed25519_provider/CMakeLists.txt
+++ b/src/crypto/ed25519_provider/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+libp2p_add_library(p2p_ed25519_provider
+        ed25519_provider_impl.cpp
+        )
+
+target_link_libraries(p2p_ed25519_provider
+        p2p_crypto_error
+        p2p_common_functions
+        OpenSSL::Crypto
+        )

--- a/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
+++ b/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
@@ -1,0 +1,123 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
+
+#include <openssl/evp.h>
+#include <libp2p/crypto/common_functions.hpp>
+#include <libp2p/crypto/error.hpp>
+#include <libp2p/crypto/sha/sha512.hpp>
+
+namespace libp2p::crypto::ed25519 {
+
+  outcome::result<Keypair> Ed25519ProviderImpl::generate() const {
+    constexpr auto FAILED{KeyGeneratorError::KEY_GENERATION_FAILED};
+
+    EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, nullptr);
+    if (nullptr == pctx) {
+      return FAILED;
+    }
+    auto free_pctx = gsl::finally([pctx] { EVP_PKEY_CTX_free(pctx); });
+
+    if (1 != EVP_PKEY_keygen_init(pctx)) {
+      return FAILED;
+    }
+
+    EVP_PKEY *pkey;
+    if (1 != EVP_PKEY_keygen(pctx, &pkey)) {
+      return FAILED;
+    }
+    auto free_pkey = gsl::finally([pkey] { EVP_PKEY_free(pkey); });
+
+    Keypair keypair{.private_key = {0}, .public_key = {0}};
+    size_t priv_len{keypair.private_key.size()};
+    size_t pub_len{keypair.public_key.size()};
+    if (1
+        != EVP_PKEY_get_raw_private_key(pkey, keypair.private_key.data(),
+                                        &priv_len)) {
+      return FAILED;
+    }
+    if (1
+        != EVP_PKEY_get_raw_public_key(pkey, keypair.public_key.data(),
+                                       &pub_len)) {
+      return FAILED;
+    }
+
+    return keypair;
+  }
+
+  outcome::result<PublicKey> Ed25519ProviderImpl::derive(
+      const PrivateKey &private_key) const {
+    OUTCOME_TRY(evp_pkey,
+                NewEvpPkeyFromBytes(EVP_PKEY_ED25519, private_key,
+                                    EVP_PKEY_new_raw_private_key));
+    PublicKey public_key{0};
+    size_t pub_len{public_key.size()};
+    if (1
+        != EVP_PKEY_get_raw_public_key(evp_pkey.get(), public_key.data(),
+                                       &pub_len)) {
+      return KeyGeneratorError::KEY_DERIVATION_FAILED;
+    }
+
+    return public_key;
+  }
+
+  outcome::result<Signature> Ed25519ProviderImpl::sign(
+      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+    OUTCOME_TRY(evp_pkey,
+                NewEvpPkeyFromBytes(EVP_PKEY_ED25519, private_key,
+                                    EVP_PKEY_new_raw_private_key));
+    constexpr auto FAILED{CryptoProviderError::SIGNATURE_GENERATION_FAILED};
+    auto digest = sha512(message);
+
+    std::shared_ptr<EVP_MD_CTX> mctx{EVP_MD_CTX_new(), EVP_MD_CTX_free};
+    if (nullptr == mctx) {
+      return FAILED;
+    }
+
+    if (1
+        != EVP_DigestSignInit(mctx.get(), nullptr, nullptr, nullptr,
+                              evp_pkey.get())) {
+      return FAILED;
+    }
+
+    Signature signature;
+    size_t signature_len{signature.size()};
+    if (1
+        != EVP_DigestSign(mctx.get(), signature.data(), &signature_len,
+                          digest.data(), digest.size())) {
+      return FAILED;
+    }
+    return signature;
+  }
+
+  outcome::result<bool> Ed25519ProviderImpl::verify(
+      gsl::span<uint8_t> message, const Signature &signature,
+      const PublicKey &public_key) const {
+    OUTCOME_TRY(evp_pkey,
+                NewEvpPkeyFromBytes(EVP_PKEY_ED25519, public_key,
+                                    EVP_PKEY_new_raw_public_key));
+    constexpr auto FAILED{CryptoProviderError::SIGNATURE_VERIFICATION_FAILED};
+    auto digest = sha512(message);
+
+    std::shared_ptr<EVP_MD_CTX> mctx{EVP_MD_CTX_new(), EVP_MD_CTX_free};
+    if (nullptr == mctx) {
+      return FAILED;
+    }
+
+    if (1
+        != EVP_DigestVerifyInit(mctx.get(), nullptr, nullptr, nullptr,
+                                evp_pkey.get())) {
+      return FAILED;
+    }
+    int valid = EVP_DigestVerify(mctx.get(), signature.data(), signature.size(),
+                                 digest.data(), digest.size());
+    if (1 == valid || 0 == valid) {
+      return valid;
+    }
+
+    return FAILED;
+  }
+}  // namespace libp2p::crypto::ed25519

--- a/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
+++ b/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
@@ -31,7 +31,7 @@ namespace libp2p::crypto::ed25519 {
     }
     auto free_pkey = gsl::finally([pkey] { EVP_PKEY_free(pkey); });
 
-    Keypair keypair{.private_key = {0}, .public_key = {0}};
+    Keypair keypair;
     size_t priv_len{keypair.private_key.size()};
     size_t pub_len{keypair.public_key.size()};
     if (1

--- a/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
+++ b/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
@@ -31,7 +31,7 @@ namespace libp2p::crypto::ed25519 {
     }
     auto free_pkey = gsl::finally([pkey] { EVP_PKEY_free(pkey); });
 
-    Keypair keypair;
+    Keypair keypair{};
     size_t priv_len{keypair.private_key.size()};
     size_t pub_len{keypair.public_key.size()};
     if (1

--- a/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
+++ b/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
@@ -25,7 +25,7 @@ namespace libp2p::crypto::ed25519 {
       return FAILED;
     }
 
-    EVP_PKEY *pkey;
+    EVP_PKEY *pkey{nullptr};  // it is mandatory to nullify the pointer!
     if (1 != EVP_PKEY_keygen(pctx, &pkey)) {
       return FAILED;
     }

--- a/src/crypto/sha/CMakeLists.txt
+++ b/src/crypto/sha/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 libp2p_add_library(p2p_sha
     sha256.cpp
+    sha512.cpp
     )
 target_link_libraries(p2p_sha
     PUBLIC

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -9,9 +9,8 @@
 
 namespace libp2p::crypto {
   common::Hash256 sha256(std::string_view input) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    const auto *bytes_ptr = reinterpret_cast<const uint8_t *>(input.data());
-    return sha256(gsl::make_span(bytes_ptr, input.length()));
+    std::vector<const uint8_t> bytes{input.begin(), input.end()};
+    return sha256(bytes);
   }
 
   common::Hash256 sha256(gsl::span<const uint8_t> input) {
@@ -20,6 +19,7 @@ namespace libp2p::crypto {
     SHA256_Init(&ctx);
     SHA256_Update(&ctx, input.data(), input.size());
     SHA256_Final(out.data(), &ctx);
+    // TODO igor-egorov FIL-67 Try to add checks for SHA-X return values
     return out;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -9,7 +9,7 @@
 
 namespace libp2p::crypto {
   common::Hash256 sha256(std::string_view input) {
-    std::vector<const uint8_t> bytes{input.begin(), input.end()};
+    std::vector<uint8_t> bytes{input.begin(), input.end()};
     return sha256(bytes);
   }
 
@@ -19,7 +19,7 @@ namespace libp2p::crypto {
     SHA256_Init(&ctx);
     SHA256_Update(&ctx, input.data(), input.size());
     SHA256_Final(out.data(), &ctx);
-    // TODO igor-egorov FIL-67 Try to add checks for SHA-X return values
+    // TODO(igor-egorov) FIL-67 Try to add checks for SHA-X return values
     return out;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -9,9 +9,8 @@
 
 namespace libp2p::crypto {
   common::Hash512 sha512(std::string_view input) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    const auto *bytes_ptr = reinterpret_cast<const uint8_t *>(input.data());
-    return sha512(gsl::make_span(bytes_ptr, input.length()));
+    std::vector<const uint8_t> bytes{input.begin(), input.end()};
+    return sha512(bytes);
   }
 
   common::Hash512 sha512(gsl::span<const uint8_t> input) {
@@ -20,6 +19,7 @@ namespace libp2p::crypto {
     SHA512_Init(&ctx);
     SHA512_Update(&ctx, input.data(), input.size());
     SHA512_Final(out.data(), &ctx);
+    // TODO igor-egorov FIL-67 Try to add checks for SHA-X return values
     return out;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -9,7 +9,7 @@
 
 namespace libp2p::crypto {
   common::Hash512 sha512(std::string_view input) {
-    std::vector<const uint8_t> bytes{input.begin(), input.end()};
+    std::vector<uint8_t> bytes{input.begin(), input.end()};
     return sha512(bytes);
   }
 
@@ -19,7 +19,7 @@ namespace libp2p::crypto {
     SHA512_Init(&ctx);
     SHA512_Update(&ctx, input.data(), input.size());
     SHA512_Final(out.data(), &ctx);
-    // TODO igor-egorov FIL-67 Try to add checks for SHA-X return values
+    // TODO(igor-egorov) FIL-67 Try to add checks for SHA-X return values
     return out;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <libp2p/crypto/sha/sha512.hpp>
+
+#include <openssl/sha.h>
+
+namespace libp2p::crypto {
+  common::Hash512 sha512(std::string_view input) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const auto *bytes_ptr = reinterpret_cast<const uint8_t *>(input.data());
+    return sha512(gsl::make_span(bytes_ptr, input.length()));
+  }
+
+  common::Hash512 sha512(gsl::span<const uint8_t> input) {
+    common::Hash512 out;
+    SHA512_CTX ctx;
+    SHA512_Init(&ctx);
+    SHA512_Update(&ctx, input.data(), input.size());
+    SHA512_Final(out.data(), &ctx);
+    return out;
+  }
+}  // namespace libp2p::crypto

--- a/test/acceptance/p2p/host/peer/test_peer.hpp
+++ b/test/acceptance/p2p/host/peer/test_peer.hpp
@@ -9,10 +9,10 @@
 #include <future>
 #include <thread>
 
-#include "libp2p/injector/host_injector.hpp"
-#include "libp2p/protocol/echo.hpp"
-#include "testutil/clock/impl/clock_impl.hpp"
-#include "testutil/outcome.hpp"
+#include <libp2p/injector/host_injector.hpp>
+#include <libp2p/protocol/echo.hpp>
+#include <testutil/clock/impl/clock_impl.hpp>
+#include <testutil/outcome.hpp>
 
 struct TickCounter;
 
@@ -33,6 +33,7 @@ class Peer {
   using Host = libp2p::Host;
   using Echo = libp2p::protocol::Echo;
   using BoostRandomGenerator = libp2p::crypto::random::BoostRandomGenerator;
+  using Ed25519Provider = libp2p::crypto::ed25519::Ed25519Provider;
   using CryptoProvider = libp2p::crypto::CryptoProvider;
 
   using Context = boost::asio::io_context;
@@ -78,6 +79,7 @@ class Peer {
   sptr<Host> host_;                             ///< host
   sptr<Echo> echo_;                             ///< echo protocol
   sptr<BoostRandomGenerator> random_provider_;  ///< random provider
+  sptr<Ed25519Provider> ed25519_provider_;      ///< ed25519 provider
   sptr<CryptoProvider> crypto_provider_;        ///< crypto provider
 };
 

--- a/test/libp2p/crypto/key_validator_test.cpp
+++ b/test/libp2p/crypto/key_validator_test.cpp
@@ -7,10 +7,11 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "libp2p/crypto/crypto_provider/crypto_provider_impl.hpp"
-#include "libp2p/crypto/key_validator/key_validator_impl.hpp"
-#include "libp2p/crypto/random_generator/boost_generator.hpp"
-#include "testutil/outcome.hpp"
+#include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
+#include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
+#include <libp2p/crypto/key_validator/key_validator_impl.hpp>
+#include <libp2p/crypto/random_generator/boost_generator.hpp>
+#include <testutil/outcome.hpp>
 
 using ::testing::_;
 using ::testing::An;
@@ -24,14 +25,19 @@ using libp2p::crypto::Key;
 using libp2p::crypto::KeyPair;
 using libp2p::crypto::PrivateKey;
 using libp2p::crypto::PublicKey;
+using libp2p::crypto::ed25519::Ed25519Provider;
+using libp2p::crypto::ed25519::Ed25519ProviderImpl;
 using libp2p::crypto::random::BoostRandomGenerator;
+using libp2p::crypto::random::CSPRNG;
 using libp2p::crypto::validator::KeyValidator;
 using libp2p::crypto::validator::KeyValidatorImpl;
 
 struct BaseKeyTest {
-  BoostRandomGenerator random;
+  std::shared_ptr<CSPRNG> random = std::make_shared<BoostRandomGenerator>();
+  std::shared_ptr<Ed25519Provider> ed25519 =
+      std::make_shared<Ed25519ProviderImpl>();
   std::shared_ptr<CryptoProvider> crypto_provider =
-      std::make_shared<CryptoProviderImpl>(random);
+      std::make_shared<CryptoProviderImpl>(random, ed25519);
   std::shared_ptr<KeyValidator> validator =
       std::make_shared<KeyValidatorImpl>(crypto_provider);
 };
@@ -74,10 +80,10 @@ TEST_P(GeneratedKeysTest, GeneratedKeysAreValid) {
  */
 TEST_P(GeneratedKeysTest, ArbitraryKeyInvalid) {
   Key::Type key_type = GetParam();
-  auto public_key = PublicKey{{key_type, random.randomBytes(64)}};
+  auto public_key = PublicKey{{key_type, random->randomBytes(64)}};
   EXPECT_OUTCOME_FALSE_1(validator->validate(public_key))
 
-  auto private_key = PrivateKey{{key_type, random.randomBytes(64)}};
+  auto private_key = PrivateKey{{key_type, random->randomBytes(64)}};
   EXPECT_OUTCOME_FALSE_1(validator->validate(private_key))
 }
 
@@ -100,7 +106,7 @@ TEST_P(GeneratedKeysTest, InvalidPublicKeyInvalidatesPair) {
   }
 
   EXPECT_OUTCOME_TRUE(key_pair, crypto_provider->generateKeys(key_type))
-  auto public_key = PublicKey{{key_type, random.randomBytes(64)}};
+  auto public_key = PublicKey{{key_type, random->randomBytes(64)}};
   EXPECT_OUTCOME_FALSE_1(validator->validate(public_key))
   auto invalid_pair = KeyPair{public_key, key_pair.privateKey};
   EXPECT_OUTCOME_FALSE_1(validator->validate(invalid_pair))
@@ -125,7 +131,7 @@ class RandomKeyTest : public BaseKeyTest,
  */
 TEST_P(RandomKeyTest, Every32byteIsValidPrivateKey) {
   auto key_type = GetParam();
-  auto sequence = random.randomBytes(32);
+  auto sequence = random->randomBytes(32);
   auto private_key = PrivateKey{{key_type, sequence}};
   EXPECT_OUTCOME_TRUE_1(validator->validate(private_key))
   EXPECT_OUTCOME_TRUE_1(crypto_provider->derivePublicKey(private_key))
@@ -145,9 +151,10 @@ class UnspecifiedKeyTest : public BaseKeyTest, public ::testing::Test {};
  */
 TEST_F(UnspecifiedKeyTest, UnspecifiedAlwaysValid) {
   auto private_key =
-      PrivateKey{{Key::Type::UNSPECIFIED, random.randomBytes(64)}};
+      PrivateKey{{Key::Type::UNSPECIFIED, random->randomBytes(64)}};
   EXPECT_OUTCOME_TRUE_1(validator->validate(private_key))
-  auto public_key = PublicKey{{Key::Type::UNSPECIFIED, random.randomBytes(64)}};
+  auto public_key =
+      PublicKey{{Key::Type::UNSPECIFIED, random->randomBytes(64)}};
   EXPECT_OUTCOME_TRUE_1(validator->validate(public_key))
   EXPECT_OUTCOME_TRUE_1(validator->validate(KeyPair{public_key, private_key}));
 }


### PR DESCRIPTION
Introduces ed25519 provider as an independent component from libp2p CryptoProvider(ex-KeyGenerator), which will be used by the CryptoProvider and can be used by other projects where libp2p is just a dependency.

Ed25519Provider operates with byte sequences.

As a side effect, - SHA512 is also implemented.

### Possible drawbacks

No tests.