### PR TITLE
use gcc9.2-friendly version of GTest

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -10,6 +10,12 @@ hunter_config(GSL
     )
 
 hunter_config(
+    GTest
+    VERSION 1.8.0-hunter-p11
+    CMAKE_ARGS "CMAKE_CXX_FLAGS=-Wno-deprecated-copy"
+)
+
+hunter_config(
     spdlog
     URL https://github.com/gabime/spdlog/archive/v1.4.2.zip
     SHA1 4b10e9aa17f7d568e24f464b48358ab46cb6f39c


### PR DESCRIPTION
Signed-off-by: Yura Zarudniy <zarudniy@soramitsu.co.jp>
Use the same (gcc9.2-friendly) version of GTest as in kagome.