### PR TITLE
Fix clang tidy concern about generated files

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -35,4 +35,6 @@ jobs:
         export LLVM_ROOT=${LLVM_DIR}/${LLVM_VER}
         export PATH=${LLVM_ROOT}/bin:${LLVM_ROOT}/share/clang:${PATH}
         cmake . -GNinja -Bbuild
+        cmake --build build --target generated
         housekeeping/clang-tidy.sh build
+


### PR DESCRIPTION
Signed-off-by: Yura Zarudniy <zarudniy@soramitsu.co.jp>
Clang tidy cannot find protobuf generated files, need to build the `generated` target before starting checks.

Added build step for `generated` target.