### PR TITLE
Feature/make secp256l1 parameters const

### DIFF
--- a/include/libp2p/crypto/secp256k1_provider.hpp
+++ b/include/libp2p/crypto/secp256k1_provider.hpp
@@ -38,7 +38,7 @@ namespace libp2p::crypto::secp256k1 {
      * @return Secp256k1 signature or error code
      */
     virtual outcome::result<Signature> sign(
-        gsl::span<uint8_t> message, const PrivateKey &key) const = 0;
+        gsl::span<const uint8_t> message, const PrivateKey &key) const = 0;
 
     /**
      * @brief Verify signature for a message
@@ -47,7 +47,7 @@ namespace libp2p::crypto::secp256k1 {
      * @param key - public key for signature verifying
      * @return Result of the verification or error code
      */
-    virtual outcome::result<bool> verify(gsl::span<uint8_t> message,
+    virtual outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                          const Signature &signature,
                                          const PublicKey &key) const = 0;
 

--- a/include/libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp
+++ b/include/libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp
@@ -20,10 +20,10 @@ namespace libp2p::crypto::secp256k1 {
         const PrivateKey &key) const override;
 
     outcome::result<Signature> sign(
-        gsl::span<uint8_t> message,
+        gsl::span<const uint8_t> message,
         const PrivateKey &key) const override;
 
-    outcome::result<bool> verify(gsl::span<uint8_t> message,
+    outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                  const Signature &signature,
                                  const PublicKey &key) const override;
 

--- a/include/libp2p/crypto/secp256k1_types.hpp
+++ b/include/libp2p/crypto/secp256k1_types.hpp
@@ -10,11 +10,14 @@
 #include <array>
 
 namespace libp2p::crypto::secp256k1 {
+
+  static const size_t kPrivateKeyLength = 32;
+  static const size_t kPublicKeyLength = 33;
   /**
    * @brief Common types
    */
-  using PrivateKey = std::array<uint8_t, 32>;
-  using PublicKey = std::array<uint8_t, 33>;
+  using PrivateKey = std::array<uint8_t, kPrivateKeyLength>;
+  using PublicKey = std::array<uint8_t, kPublicKeyLength>;
   using Signature = std::vector<uint8_t>;
 
   /**

--- a/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
+++ b/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
@@ -53,7 +53,7 @@ namespace libp2p::crypto::secp256k1 {
   }
 
   outcome::result<Signature> Secp256k1ProviderImpl::sign(
-      gsl::span<uint8_t> message, const PrivateKey &key) const {
+      gsl::span<const uint8_t> message, const PrivateKey &key) const {
     common::Hash256 digest = sha256(message);
     OUTCOME_TRY(private_key, bytesToPrivateKey(key));
     OUTCOME_TRY(signature, GenerateEcSignature(digest, private_key));
@@ -61,7 +61,7 @@ namespace libp2p::crypto::secp256k1 {
   }
 
   outcome::result<bool> Secp256k1ProviderImpl::verify(
-      gsl::span<uint8_t> message, const Signature &signature,
+      gsl::span<const uint8_t> message, const Signature &signature,
       const PublicKey &key) const {
     common::Hash256 digest = sha256(message);
     OUTCOME_TRY(public_key, bytesToPublicKey(key));


### PR DESCRIPTION
Make parameters const, add key length.

Inspired by https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#span-and-const-whats-the-difference-between-spanconst-t-and-const-spant