### PR TITLE
Update github pipeline macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # 3 jobs in total
-        os: [ubuntu-18.04, macOS-10.14]
+        os: [ubuntu-18.04, macOS-latest]
         compiler: [{
           "cc": "gcc",
           "cxx": "g++"
@@ -24,7 +24,7 @@ jobs:
           "cxx": "clang++"
         }]
         exclude:
-          - os: macOS-10.14
+          - os: macOS-latest
             compiler:
               cc: gcc
     steps:


### PR DESCRIPTION
### Description of the Change

Update github pipeline macos

```The macOS virtual environment has been updated to Catalina (v10.15). Starting January 15th, jobs that include the line 'runs-on: macOS-10.14' will fail to run and return a failed check suite. Please update your workflow and change the line 'runs-on: macOS-10.14' to 'runs-on: macOS-latest'.```

### Benefits

Macos pipeline will continue working

### Possible Drawbacks 

Macos pipeline will stop working