### PR TITLE
Refactor Crypto Provider Implementation

### DIFF
--- a/example/02-kad/factory.cpp
+++ b/example/02-kad/factory.cpp
@@ -14,6 +14,7 @@
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
 #include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
+#include <libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp>
 #include <libp2p/host/basic_host.hpp>
 #include <libp2p/muxer/mplex.hpp>
 #include <libp2p/muxer/yamux.hpp>
@@ -81,9 +82,12 @@ namespace libp2p::protocol::kademlia::example {
       auto rsa_provider = std::make_shared<crypto::rsa::RsaProviderImpl>();
       auto ecdsa_provider =
           std::make_shared<crypto::ecdsa::EcdsaProviderImpl>();
+      auto secp256k1_provider =
+          std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>();
       std::shared_ptr<crypto::CryptoProvider> crypto_provider =
           std::make_shared<crypto::CryptoProviderImpl>(
-              csprng, ed25519_provider, rsa_provider, ecdsa_provider);
+              csprng, ed25519_provider, rsa_provider, ecdsa_provider,
+              secp256k1_provider);
       auto validator = std::make_shared<crypto::validator::KeyValidatorImpl>(
           crypto_provider);
 

--- a/example/02-kad/factory.cpp
+++ b/example/02-kad/factory.cpp
@@ -138,7 +138,8 @@ namespace libp2p::protocol::kademlia::example {
     }
   }  // namespace
 
-  void createPerHostObjects(PerHostObjects &objects, const KademliaConfig& conf) {
+  void createPerHostObjects(PerHostObjects &objects,
+                            const KademliaConfig &conf) {
     auto injector = makeInjector(boost::di::bind<boost::asio::io_context>.to(
         createIOContext())[boost::di::override]);
 
@@ -147,12 +148,9 @@ namespace libp2p::protocol::kademlia::example {
         injector.create<std::shared_ptr<libp2p::crypto::CryptoProvider>>();
     objects.key_marshaller = injector.create<
         std::shared_ptr<libp2p::crypto::marshaller::KeyMarshaller>>();
-    objects.routing_table =
-        std::make_shared<RoutingTableImpl>(
-            injector.create<std::shared_ptr<peer::IdentityManager>>(),
-            injector.create<std::shared_ptr<event::Bus>>(),
-            conf
-    );
+    objects.routing_table = std::make_shared<RoutingTableImpl>(
+        injector.create<std::shared_ptr<peer::IdentityManager>>(),
+        injector.create<std::shared_ptr<event::Bus>>(), conf);
   }
 
   std::shared_ptr<boost::asio::io_context> createIOContext() {
@@ -161,4 +159,4 @@ namespace libp2p::protocol::kademlia::example {
     return c;
   }
 
-}  // namespace libp2p::kad_example
+}  // namespace libp2p::protocol::kademlia::example

--- a/example/02-kad/factory.cpp
+++ b/example/02-kad/factory.cpp
@@ -8,10 +8,12 @@
 
 // implementations
 #include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
+#include <libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp>
 #include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
+#include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
 #include <libp2p/host/basic_host.hpp>
 #include <libp2p/muxer/mplex.hpp>
 #include <libp2p/muxer/yamux.hpp>
@@ -40,8 +42,8 @@
 
 namespace libp2p::protocol::kademlia::example {
 
-  std::optional<libp2p::peer::PeerInfo> str2peerInfo(const std::string &str) {
-    using R = std::optional<libp2p::peer::PeerInfo>;
+  boost::optional<libp2p::peer::PeerInfo> str2peerInfo(const std::string &str) {
+    using R = boost::optional<libp2p::peer::PeerInfo>;
 
     auto server_ma_res = libp2p::multi::Multiaddress::create(str);
     if (!server_ma_res) {
@@ -76,8 +78,12 @@ namespace libp2p::protocol::kademlia::example {
       auto csprng = std::make_shared<crypto::random::BoostRandomGenerator>();
       auto ed25519_provider =
           std::make_shared<crypto::ed25519::Ed25519ProviderImpl>();
-      auto crypto_provider = std::make_shared<crypto::CryptoProviderImpl>(
-          csprng, ed25519_provider);
+      auto rsa_provider = std::make_shared<crypto::rsa::RsaProviderImpl>();
+      auto ecdsa_provider =
+          std::make_shared<crypto::ecdsa::EcdsaProviderImpl>();
+      std::shared_ptr<crypto::CryptoProvider> crypto_provider =
+          std::make_shared<crypto::CryptoProviderImpl>(
+              csprng, ed25519_provider, rsa_provider, ecdsa_provider);
       auto validator = std::make_shared<crypto::validator::KeyValidatorImpl>(
           crypto_provider);
 

--- a/example/02-kad/factory.hpp
+++ b/example/02-kad/factory.hpp
@@ -21,9 +21,10 @@ namespace libp2p::protocol::kademlia::example {
     std::shared_ptr<crypto::marshaller::KeyMarshaller> key_marshaller;
   };
 
-  void createPerHostObjects(PerHostObjects &objects, const KademliaConfig& conf);
+  void createPerHostObjects(PerHostObjects &objects,
+                            const KademliaConfig &conf);
 
-  std::optional<libp2p::peer::PeerInfo> str2peerInfo(const std::string &str);
+  boost::optional<libp2p::peer::PeerInfo> str2peerInfo(const std::string &str);
 
 }  // namespace libp2p::protocol::kademlia::example
 

--- a/example/02-kad/kad_peer_discovery_example.cpp
+++ b/example/02-kad/kad_peer_discovery_example.cpp
@@ -29,7 +29,7 @@ namespace libp2p::protocol::kademlia::example {
         .value();
   }
 
-  const KademliaConfig& getConfig() {
+  const KademliaConfig &getConfig() {
     static KademliaConfig config = ([] {
       KademliaConfig c;
       c.randomWalk.delay = 5s;
@@ -45,7 +45,7 @@ namespace libp2p::protocol::kademlia::example {
       std::shared_ptr<KadImpl> kad;
       std::string listen_to;
       std::string connect_to;
-      std::optional<libp2p::peer::PeerId> find_id;
+      boost::optional<libp2p::peer::PeerId> find_id;
       Scheduler::Handle htimer;
       Scheduler::Handle hbootstrap;
       bool found = false;
@@ -53,13 +53,13 @@ namespace libp2p::protocol::kademlia::example {
       bool request_sent = false;
 
       Host(size_t i, std::shared_ptr<Scheduler> sch, PerHostObjects obj)
-        : index(i), o(std::move(obj))
+          : index(i),
+            o(std::move(obj))
 
       {
-        kad = std::make_shared<KadImpl>(
-            o.host, std::move(sch), o.routing_table,
-            createDefaultValueStoreBackend(), getConfig()
-        );
+        kad = std::make_shared<KadImpl>(o.host, std::move(sch), o.routing_table,
+                                        createDefaultValueStoreBackend(),
+                                        getConfig());
       }
 
       void checkPeers() {
@@ -90,7 +90,6 @@ namespace libp2p::protocol::kademlia::example {
         kad->start(true);
       }
 
-
       void connect() {
         if (connect_to.empty())
           return;
@@ -100,8 +99,10 @@ namespace libp2p::protocol::kademlia::example {
 
       void findPeer(const libp2p::peer::PeerId &id) {
         find_id = id;
-        htimer = kad->scheduler().schedule(20000, [this] { onFindPeerTimer(); });
-        hbootstrap = kad->scheduler().schedule(100, [this] { onBootstrapTimer(); });
+        htimer =
+            kad->scheduler().schedule(20000, [this] { onFindPeerTimer(); });
+        hbootstrap =
+            kad->scheduler().schedule(100, [this] { onBootstrapTimer(); });
       }
 
       void onBootstrapTimer() {
@@ -110,7 +111,7 @@ namespace libp2p::protocol::kademlia::example {
           request_sent =
               kad->findPeer(genRandomPeerId(*o.key_gen, *o.key_marshaller),
                             [this](const libp2p::peer::PeerId &peer,
-                                   Kad::FindPeerQueryResult res) { //NOLINT
+                                   Kad::FindPeerQueryResult res) {  // NOLINT
                               logger->info(
                                   "bootstrap return from findPeer, i={}, "
                                   "peer={} peers={} ({})",
@@ -151,8 +152,8 @@ namespace libp2p::protocol::kademlia::example {
           logger->info("onFindPeer: i={}, res: success={}, peers={}", index,
                        res.success, res.closer_peers.size());
 
-        htimer =
-            kad->scheduler().schedule(1000, [this, peers = std::move(res.closer_peers)] {
+        htimer = kad->scheduler().schedule(
+            1000, [this, peers = std::move(res.closer_peers)] {
               kad->findPeer(find_id.value(),
                             [this](const libp2p::peer::PeerId &peer,
                                    Kad::FindPeerQueryResult res) {
@@ -172,7 +173,7 @@ namespace libp2p::protocol::kademlia::example {
 
     std::vector<Host> hosts;
 
-    Hosts(size_t n, const std::shared_ptr<Scheduler>& sch) {
+    Hosts(size_t n, const std::shared_ptr<Scheduler> &sch) {
       hosts.reserve(n);
 
       for (size_t i = 0; i < n; ++i) {
@@ -182,7 +183,7 @@ namespace libp2p::protocol::kademlia::example {
       makeConnectTopologyCircle();
     }
 
-    void newHost(const std::shared_ptr<Scheduler>& sch) {
+    void newHost(const std::shared_ptr<Scheduler> &sch) {
       size_t index = hosts.size();
       PerHostObjects o;
       createPerHostObjects(o, getConfig());
@@ -264,9 +265,9 @@ int main(int argc, char *argv[]) {
     size_t hosts_count = 6;
     bool kad_log_debug = false;
     if (argc > 1)
-      hosts_count = atoi(argv[1]); //NOLINT
+      hosts_count = atoi(argv[1]);  // NOLINT
     if (argc > 2)
-      kad_log_debug = (atoi(argv[2]) != 0); //NOLINT
+      kad_log_debug = (atoi(argv[2]) != 0);  // NOLINT
 
     x::setupLoggers(kad_log_debug);
 

--- a/include/libp2p/crypto/crypto_provider.hpp
+++ b/include/libp2p/crypto/crypto_provider.hpp
@@ -50,7 +50,8 @@ namespace libp2p::crypto {
      * @return signature bytes
      */
     virtual outcome::result<Buffer> sign(
-        gsl::span<uint8_t> message, const PrivateKey &private_key) const = 0;
+        gsl::span<const uint8_t> message,
+        const PrivateKey &private_key) const = 0;
 
     /**
      * @brief verifies validness of the signature for a given message and public
@@ -60,8 +61,8 @@ namespace libp2p::crypto {
      * @param public_key to validate against
      * @return true - if the signature matches the message and the public key
      */
-    virtual outcome::result<bool> verify(gsl::span<uint8_t> message,
-                                         gsl::span<uint8_t> signature,
+    virtual outcome::result<bool> verify(gsl::span<const uint8_t> message,
+                                         gsl::span<const uint8_t> signature,
                                          const PublicKey &public_key) const = 0;
     /**
      * Generate an ephemeral public key and return a function that will

--- a/include/libp2p/crypto/crypto_provider.hpp
+++ b/include/libp2p/crypto/crypto_provider.hpp
@@ -6,12 +6,13 @@
 #ifndef LIBP2P_CRYPTO_PROVIDER_HPP
 #define LIBP2P_CRYPTO_PROVIDER_HPP
 
+#include <vector>
+
 #include <boost/filesystem.hpp>
 #include <gsl/span>
 #include <libp2p/crypto/common.hpp>
 #include <libp2p/crypto/key.hpp>
 #include <libp2p/outcome/outcome.hpp>
-#include <vector>
 
 namespace libp2p::crypto {
   /**
@@ -27,9 +28,12 @@ namespace libp2p::crypto {
     /**
      * @brief generates new key pair of specified type
      * @param key_type key type
+     * @param rsa_bitness specifies the length of RSA key
      * @return new generated key pair of public and private key or error
      */
-    virtual outcome::result<KeyPair> generateKeys(Key::Type key_type) const = 0;
+    virtual outcome::result<KeyPair> generateKeys(
+        Key::Type key_type,
+        common::RSAKeyType rsa_bitness = common::RSAKeyType::RSA2048) const = 0;
 
     /**
      * @brief derives public key from private key

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -21,6 +21,9 @@ namespace libp2p::crypto {
   namespace ecdsa {
     class EcdsaProvider;
   }
+  namespace secp256k1 {
+    class Secp256k1Provider;
+  }
 
   class CryptoProviderImpl : public CryptoProvider {
    public:
@@ -30,7 +33,8 @@ namespace libp2p::crypto {
         std::shared_ptr<random::CSPRNG> random_provider,
         std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider,
         std::shared_ptr<rsa::RsaProvider> rsa_provider,
-        std::shared_ptr<ecdsa::EcdsaProvider> ecdsa_provider);
+        std::shared_ptr<ecdsa::EcdsaProvider> ecdsa_provider,
+        std::shared_ptr<secp256k1::Secp256k1Provider> secp256k1_provider);
 
     outcome::result<KeyPair> generateKeys(
         Key::Type key_type, common::RSAKeyType rsa_bitness) const override;
@@ -75,6 +79,12 @@ namespace libp2p::crypto {
 
     // Secp256k1
     outcome::result<KeyPair> generateSecp256k1() const;
+    outcome::result<PublicKey> deriveSecp256k1(const PrivateKey &key) const;
+    outcome::result<Buffer> signSecp256k1(gsl::span<const uint8_t> message,
+                                          const PrivateKey &private_key) const;
+    outcome::result<bool> verifySecp256k1(gsl::span<const uint8_t> message,
+                                          gsl::span<const uint8_t> signature,
+                                          const PublicKey &public_key) const;
 
     // ECDSA
     outcome::result<KeyPair> generateEcdsa() const;
@@ -92,6 +102,7 @@ namespace libp2p::crypto {
     std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider_;
     std::shared_ptr<rsa::RsaProvider> rsa_provider_;
     std::shared_ptr<ecdsa::EcdsaProvider> ecdsa_provider_;
+    std::shared_ptr<secp256k1::Secp256k1Provider> secp256k1_provider_;
   };
 }  // namespace libp2p::crypto
 

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -18,6 +18,9 @@ namespace libp2p::crypto {
   namespace rsa {
     class RsaProvider;
   }
+  namespace ecdsa {
+    class EcdsaProvider;
+  }
 
   class CryptoProviderImpl : public CryptoProvider {
    public:
@@ -26,7 +29,8 @@ namespace libp2p::crypto {
     explicit CryptoProviderImpl(
         std::shared_ptr<random::CSPRNG> random_provider,
         std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider,
-        std::shared_ptr<rsa::RsaProvider> rsa_provider);
+        std::shared_ptr<rsa::RsaProvider> rsa_provider,
+        std::shared_ptr<ecdsa::EcdsaProvider> ecdsa_provider);
 
     outcome::result<KeyPair> generateKeys(
         Key::Type key_type, common::RSAKeyType rsa_bitness) const override;
@@ -72,8 +76,14 @@ namespace libp2p::crypto {
     // Secp256k1
     outcome::result<KeyPair> generateSecp256k1() const;
 
-    // EcDSA
+    // ECDSA
     outcome::result<KeyPair> generateEcdsa() const;
+    outcome::result<PublicKey> deriveEcdsa(const PrivateKey &key) const;
+    outcome::result<Buffer> signEcdsa(gsl::span<const uint8_t> message,
+                                      const PrivateKey &private_key) const;
+    outcome::result<bool> verifyEcdsa(gsl::span<const uint8_t> message,
+                                      gsl::span<const uint8_t> signature,
+                                      const PublicKey &public_key) const;
 
     outcome::result<KeyPair> generateEcdsa256WithCurve(Key::Type key_type,
                                                        int curve_nid) const;
@@ -81,6 +91,7 @@ namespace libp2p::crypto {
     std::shared_ptr<random::CSPRNG> random_provider_;
     std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider_;
     std::shared_ptr<rsa::RsaProvider> rsa_provider_;
+    std::shared_ptr<ecdsa::EcdsaProvider> ecdsa_provider_;
   };
 }  // namespace libp2p::crypto
 

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -95,9 +95,6 @@ namespace libp2p::crypto {
                                       gsl::span<const uint8_t> signature,
                                       const PublicKey &public_key) const;
 
-    outcome::result<KeyPair> generateEcdsa256WithCurve(Key::Type key_type,
-                                                       int curve_nid) const;
-
     std::shared_ptr<random::CSPRNG> random_provider_;
     std::shared_ptr<ed25519::Ed25519Provider> ed25519_provider_;
     std::shared_ptr<rsa::RsaProvider> rsa_provider_;

--- a/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
+++ b/include/libp2p/crypto/crypto_provider/crypto_provider_impl.hpp
@@ -34,11 +34,11 @@ namespace libp2p::crypto {
     outcome::result<PublicKey> derivePublicKey(
         const PrivateKey &private_key) const override;
 
-    outcome::result<Buffer> sign(gsl::span<uint8_t> message,
+    outcome::result<Buffer> sign(gsl::span<const uint8_t> message,
                                  const PrivateKey &private_key) const override;
 
-    outcome::result<bool> verify(gsl::span<uint8_t> message,
-                                 gsl::span<uint8_t> signature,
+    outcome::result<bool> verify(gsl::span<const uint8_t> message,
+                                 gsl::span<const uint8_t> signature,
                                  const PublicKey &public_key) const override;
 
     outcome::result<EphemeralKeyPair> generateEphemeralKeyPair(
@@ -63,10 +63,10 @@ namespace libp2p::crypto {
     // Ed25519
     outcome::result<KeyPair> generateEd25519() const;
     outcome::result<PublicKey> deriveEd25519(const PrivateKey &key) const;
-    outcome::result<Buffer> signEd25519(gsl::span<uint8_t> message,
+    outcome::result<Buffer> signEd25519(gsl::span<const uint8_t> message,
                                         const PrivateKey &private_key) const;
-    outcome::result<bool> verifyEd25519(gsl::span<uint8_t> message,
-                                        gsl::span<uint8_t> signature,
+    outcome::result<bool> verifyEd25519(gsl::span<const uint8_t> message,
+                                        gsl::span<const uint8_t> signature,
                                         const PublicKey &public_key) const;
 
     // Secp256k1

--- a/include/libp2p/crypto/ecdsa_provider.hpp
+++ b/include/libp2p/crypto/ecdsa_provider.hpp
@@ -17,14 +17,14 @@ namespace libp2p::crypto::ecdsa {
      * @brief Generate private and public keys
      * @return ECDSA key pair or error code
      */
-    virtual outcome::result<KeyPair> GenerateKeyPair() const = 0;
+    virtual outcome::result<KeyPair> generate() const = 0;
 
     /**
      * @brief Generate ECDSA public key from private key
      * @param key - ECDSA private key
      * @return Generated public key or error code
      */
-    virtual outcome::result<PublicKey> DerivePublicKey(const PrivateKey &key) const = 0;
+    virtual outcome::result<PublicKey> derive(const PrivateKey &key) const = 0;
 
     /**
      * @brief Create signature for a message
@@ -32,7 +32,7 @@ namespace libp2p::crypto::ecdsa {
      * @param privateKey - key for signing
      * @return ECDSA signature or error code
      */
-    virtual outcome::result<Signature> Sign(gsl::span<uint8_t> message,
+    virtual outcome::result<Signature> sign(gsl::span<const uint8_t> message,
                                             const PrivateKey &key) const = 0;
 
     /**
@@ -42,7 +42,7 @@ namespace libp2p::crypto::ecdsa {
      * @param publicKey - key for signature verifying
      * @return Result of the verification or error code
      */
-    virtual outcome::result<bool> Verify(gsl::span<uint8_t> message,
+    virtual outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                          const Signature &signature,
                                          const PublicKey &publicKey) const = 0;
 

--- a/include/libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp
+++ b/include/libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp
@@ -12,17 +12,17 @@
 #include <libp2p/crypto/ecdsa_provider.hpp>
 
 namespace libp2p::crypto::ecdsa {
+
   class EcdsaProviderImpl : public EcdsaProvider {
    public:
-    outcome::result<KeyPair> GenerateKeyPair() const override;
+    outcome::result<KeyPair> generate() const override;
 
-    outcome::result<PublicKey> DerivePublicKey(
-        const PrivateKey &key) const override;
+    outcome::result<PublicKey> derive(const PrivateKey &key) const override;
 
-    outcome::result<Signature> Sign(gsl::span<uint8_t> message,
+    outcome::result<Signature> sign(gsl::span<const uint8_t> message,
                                     const PrivateKey &key) const override;
 
-    outcome::result<bool> Verify(gsl::span<uint8_t> message,
+    outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                  const Signature &signature,
                                  const PublicKey &key) const override;
 
@@ -35,7 +35,7 @@ namespace libp2p::crypto::ecdsa {
      * @return Converted key or error code
      */
     template <typename KeyType>
-    outcome::result<KeyType> ConvertEcKeyToBytes(
+    outcome::result<KeyType> convertEcKeyToBytes(
         const std::shared_ptr<EC_KEY> &ec_key,
         int (*converter)(EC_KEY *, uint8_t **)) const;
 
@@ -47,7 +47,7 @@ namespace libp2p::crypto::ecdsa {
      * @return Converted key or error code
      */
     template <typename KeyType>
-    outcome::result<std::shared_ptr<EC_KEY>> ConvertBytesToEcKey(
+    outcome::result<std::shared_ptr<EC_KEY>> convertBytesToEcKey(
         const KeyType &key,
         EC_KEY *(*converter)(EC_KEY **, const uint8_t **, long)) const;
   };

--- a/include/libp2p/crypto/ed25519_provider.hpp
+++ b/include/libp2p/crypto/ed25519_provider.hpp
@@ -47,7 +47,8 @@ namespace libp2p::crypto::ed25519 {
      * @return signature as bytes sequence
      */
     virtual outcome::result<Signature> sign(
-        gsl::span<uint8_t> message, const PrivateKey &private_key) const = 0;
+        gsl::span<const uint8_t> message,
+        const PrivateKey &private_key) const = 0;
 
     /**
      * Verify signature of a message against a given public key
@@ -56,7 +57,7 @@ namespace libp2p::crypto::ed25519 {
      * @param public_key - public key bytes
      * @return - true when signature is valid, false - otherwise
      */
-    virtual outcome::result<bool> verify(gsl::span<uint8_t> message,
+    virtual outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                          const Signature &signature,
                                          const PublicKey &public_key) const = 0;
 

--- a/include/libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp
+++ b/include/libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp
@@ -18,10 +18,10 @@ namespace libp2p::crypto::ed25519 {
         const PrivateKey &private_key) const override;
 
     outcome::result<Signature> sign(
-        gsl::span<uint8_t> message,
+        gsl::span<const uint8_t> message,
         const PrivateKey &private_key) const override;
 
-    outcome::result<bool> verify(gsl::span<uint8_t> message,
+    outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                  const Signature &signature,
                                  const PublicKey &public_key) const override;
   };

--- a/include/libp2p/crypto/rsa_provider.hpp
+++ b/include/libp2p/crypto/rsa_provider.hpp
@@ -7,8 +7,8 @@
 #define LIBP2P_CRYPTO_RSA_PROVIDER_HPP
 
 #include <gsl/span>
-#include <libp2p/outcome/outcome.hpp>
 #include <libp2p/crypto/rsa_types.hpp>
+#include <libp2p/outcome/outcome.hpp>
 
 namespace libp2p::crypto::rsa {
 
@@ -18,13 +18,28 @@ namespace libp2p::crypto::rsa {
   class RsaProvider {
    public:
     /**
+     * @brief Generate private and public keys
+     * @return RSA key pair or error code
+     */
+    virtual outcome::result<KeyPair> generate(RSAKeyType rsa_bitness) const = 0;
+
+    /**
+     * @brief Generate public key from private key
+     * @param key - private key for deriving public key
+     * @return Derived public key or error code
+     */
+    virtual outcome::result<PublicKey> derive(
+        const PrivateKey &private_key) const = 0;
+
+    /**
      * Sign a message using private key. Message digest calculated as SHA512
      * @param message - the source message as bytes sequence
      * @param private_key - private key bytes
      * @return signature as bytes sequence
      */
-    virtual outcome::result<Signature> sign(gsl::span<uint8_t> message,
-                                            const PrivateKey &private_key) const = 0;
+    virtual outcome::result<Signature> sign(
+        gsl::span<const uint8_t> message,
+        const PrivateKey &private_key) const = 0;
 
     /**
      * @brief Verify signature for a message
@@ -33,7 +48,7 @@ namespace libp2p::crypto::rsa {
      * @param key - key for signature verifying
      * @return Result of the verification or error code
      */
-    virtual outcome::result<bool> verify(gsl::span<uint8_t> message,
+    virtual outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                          const Signature &signature,
                                          const PublicKey &key) const = 0;
 

--- a/include/libp2p/crypto/rsa_provider/rsa_provider_impl.hpp
+++ b/include/libp2p/crypto/rsa_provider/rsa_provider_impl.hpp
@@ -19,10 +19,16 @@ namespace libp2p::crypto::rsa {
    */
   class RsaProviderImpl : public RsaProvider {
    public:
-    outcome::result<Signature> sign(gsl::span<uint8_t> message,
-                                    const PrivateKey &private_key) const override;
+    outcome::result<KeyPair> generate(RSAKeyType rsa_bitness) const override;
 
-    outcome::result<bool> verify(gsl::span<uint8_t> message,
+    outcome::result<PublicKey> derive(
+        const PrivateKey &private_key) const override;
+
+    outcome::result<Signature> sign(
+        gsl::span<const uint8_t> message,
+        const PrivateKey &private_key) const override;
+
+    outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                  const Signature &signature,
                                  const PublicKey &key) const override;
 

--- a/include/libp2p/crypto/rsa_types.hpp
+++ b/include/libp2p/crypto/rsa_types.hpp
@@ -8,6 +8,8 @@
 
 #include <vector>
 
+#include <libp2p/crypto/common.hpp>
+
 namespace libp2p::crypto::rsa {
   /**
    * @brief Common types
@@ -15,10 +17,11 @@ namespace libp2p::crypto::rsa {
   using PrivateKey = std::vector<uint8_t>; /**< RSA private key */
   using PublicKey = std::vector<uint8_t>;  /**< RSA public key */
   using Signature = std::vector<uint8_t>;  /**< RSA signature of a message */
+  using libp2p::crypto::common::RSAKeyType;
 
   struct KeyPair {
     PrivateKey private_key; /**< RSA private key */
-    PublicKey public_key;  /**< RSA public key */
+    PublicKey public_key;   /**< RSA public key */
 
     /**
      * @brief Comparing keypairs

--- a/include/libp2p/crypto/secp256k1_provider.hpp
+++ b/include/libp2p/crypto/secp256k1_provider.hpp
@@ -7,8 +7,8 @@
 #define LIBP2P_CRYPTO_SECP256K1_PROVIDER_HPP
 
 #include <gsl/span>
-#include <libp2p/outcome/outcome.hpp>
 #include <libp2p/crypto/secp256k1_types.hpp>
+#include <libp2p/outcome/outcome.hpp>
 
 namespace libp2p::crypto::secp256k1 {
 
@@ -21,15 +21,14 @@ namespace libp2p::crypto::secp256k1 {
      * @brief Generate private and public keys
      * @return Secp256k1 key pair or error code
      */
-    virtual outcome::result<KeyPair> generateKeyPair() const = 0;
+    virtual outcome::result<KeyPair> generate() const = 0;
 
     /**
      * @brief Generate public key from private key
      * @param key - private key for deriving public key
      * @return Derived public key or error code
      */
-    virtual outcome::result<PublicKey> derivePublicKey(
-        const PrivateKey &key) const = 0;
+    virtual outcome::result<PublicKey> derive(const PrivateKey &key) const = 0;
 
     /**
      * @brief Create signature for a message
@@ -37,8 +36,8 @@ namespace libp2p::crypto::secp256k1 {
      * @param key - private key for signing
      * @return Secp256k1 signature or error code
      */
-    virtual outcome::result<Signature> sign(
-        gsl::span<const uint8_t> message, const PrivateKey &key) const = 0;
+    virtual outcome::result<Signature> sign(gsl::span<const uint8_t> message,
+                                            const PrivateKey &key) const = 0;
 
     /**
      * @brief Verify signature for a message

--- a/include/libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp
+++ b/include/libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp
@@ -14,14 +14,12 @@
 namespace libp2p::crypto::secp256k1 {
   class Secp256k1ProviderImpl : public Secp256k1Provider {
    public:
-    outcome::result<KeyPair> generateKeyPair() const override;
+    outcome::result<KeyPair> generate() const override;
 
-    outcome::result<PublicKey> derivePublicKey(
-        const PrivateKey &key) const override;
+    outcome::result<PublicKey> derive(const PrivateKey &key) const override;
 
-    outcome::result<Signature> sign(
-        gsl::span<const uint8_t> message,
-        const PrivateKey &key) const override;
+    outcome::result<Signature> sign(gsl::span<const uint8_t> message,
+                                    const PrivateKey &key) const override;
 
     outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                  const Signature &signature,

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -14,6 +14,7 @@
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
+#include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
 #include <libp2p/muxer/mplex.hpp>
 #include <libp2p/muxer/yamux.hpp>
 #include <libp2p/network/impl/connection_manager_impl.hpp>
@@ -227,8 +228,10 @@ namespace libp2p::injector {
     auto csprng = std::make_shared<crypto::random::BoostRandomGenerator>();
     auto ed25519_provider =
         std::make_shared<crypto::ed25519::Ed25519ProviderImpl>();
-    auto crypto_provider =
-        std::make_shared<crypto::CryptoProviderImpl>(csprng, ed25519_provider);
+    auto rsa_provider = std::make_shared<crypto::rsa::RsaProviderImpl>();
+    std::shared_ptr<crypto::CryptoProvider> crypto_provider =
+        std::make_shared<crypto::CryptoProviderImpl>(csprng, ed25519_provider,
+                                                     rsa_provider);
     auto validator =
         std::make_shared<crypto::validator::KeyValidatorImpl>(crypto_provider);
 
@@ -241,6 +244,7 @@ namespace libp2p::injector {
         di::bind<crypto::KeyPair>().template to(std::move(keypair)),
         di::bind<crypto::random::CSPRNG>().template to(std::move(csprng)),
         di::bind<crypto::ed25519::Ed25519Provider>().template to(std::move(ed25519_provider)),
+        di::bind<crypto::rsa::RsaProvider>().template to(std::move(rsa_provider)),
         di::bind<crypto::CryptoProvider>().template to<crypto::CryptoProviderImpl>(),
         di::bind<crypto::marshaller::KeyMarshaller>().template to<crypto::marshaller::KeyMarshallerImpl>(),
         di::bind<peer::IdentityManager>().template to<peer::IdentityManagerImpl>(),

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -10,6 +10,7 @@
 
 // implementations
 #include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
+#include <libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp>
 #include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
@@ -229,9 +230,10 @@ namespace libp2p::injector {
     auto ed25519_provider =
         std::make_shared<crypto::ed25519::Ed25519ProviderImpl>();
     auto rsa_provider = std::make_shared<crypto::rsa::RsaProviderImpl>();
+    auto ecdsa_provider = std::make_shared<crypto::ecdsa::EcdsaProviderImpl>();
     std::shared_ptr<crypto::CryptoProvider> crypto_provider =
-        std::make_shared<crypto::CryptoProviderImpl>(csprng, ed25519_provider,
-                                                     rsa_provider);
+        std::make_shared<crypto::CryptoProviderImpl>(
+            csprng, ed25519_provider, rsa_provider, ecdsa_provider);
     auto validator =
         std::make_shared<crypto::validator::KeyValidatorImpl>(crypto_provider);
 
@@ -245,6 +247,7 @@ namespace libp2p::injector {
         di::bind<crypto::random::CSPRNG>().template to(std::move(csprng)),
         di::bind<crypto::ed25519::Ed25519Provider>().template to(std::move(ed25519_provider)),
         di::bind<crypto::rsa::RsaProvider>().template to(std::move(rsa_provider)),
+        di::bind<crypto::ecdsa::EcdsaProvider>().template to(std::move(ecdsa_provider)),
         di::bind<crypto::CryptoProvider>().template to<crypto::CryptoProviderImpl>(),
         di::bind<crypto::marshaller::KeyMarshaller>().template to<crypto::marshaller::KeyMarshallerImpl>(),
         di::bind<peer::IdentityManager>().template to<peer::IdentityManagerImpl>(),

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -16,6 +16,7 @@
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
 #include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
+#include <libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp>
 #include <libp2p/muxer/mplex.hpp>
 #include <libp2p/muxer/yamux.hpp>
 #include <libp2p/network/impl/connection_manager_impl.hpp>
@@ -231,9 +232,12 @@ namespace libp2p::injector {
         std::make_shared<crypto::ed25519::Ed25519ProviderImpl>();
     auto rsa_provider = std::make_shared<crypto::rsa::RsaProviderImpl>();
     auto ecdsa_provider = std::make_shared<crypto::ecdsa::EcdsaProviderImpl>();
+    auto secp256k1_provider =
+        std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>();
     std::shared_ptr<crypto::CryptoProvider> crypto_provider =
         std::make_shared<crypto::CryptoProviderImpl>(
-            csprng, ed25519_provider, rsa_provider, ecdsa_provider);
+            csprng, ed25519_provider, rsa_provider, ecdsa_provider,
+            secp256k1_provider);
     auto validator =
         std::make_shared<crypto::validator::KeyValidatorImpl>(crypto_provider);
 
@@ -248,6 +252,7 @@ namespace libp2p::injector {
         di::bind<crypto::ed25519::Ed25519Provider>().template to(std::move(ed25519_provider)),
         di::bind<crypto::rsa::RsaProvider>().template to(std::move(rsa_provider)),
         di::bind<crypto::ecdsa::EcdsaProvider>().template to(std::move(ecdsa_provider)),
+        di::bind<crypto::secp256k1::Secp256k1Provider>().template to(std::move(secp256k1_provider)),
         di::bind<crypto::CryptoProvider>().template to<crypto::CryptoProviderImpl>(),
         di::bind<crypto::marshaller::KeyMarshaller>().template to<crypto::marshaller::KeyMarshallerImpl>(),
         di::bind<peer::IdentityManager>().template to<peer::IdentityManagerImpl>(),

--- a/include/libp2p/protocol/kademlia/impl/kad_message.hpp
+++ b/include/libp2p/protocol/kademlia/impl/kad_message.hpp
@@ -40,9 +40,9 @@ namespace libp2p::protocol::kademlia {
 
     Type type = kPing;
     std::vector<uint8_t> key;
-    std::optional<Record> record;
-    std::optional<Peers> closer_peers;
-    std::optional<Peers> provider_peers;
+    boost::optional<Record> record;
+    boost::optional<Peers> closer_peers;
+    boost::optional<Peers> provider_peers;
 
     void clear();
 
@@ -58,14 +58,14 @@ namespace libp2p::protocol::kademlia {
 
   // self is a protocol extension if this is server (i.e. announce)
   Message createFindNodeRequest(const peer::PeerId &node,
-                                std::optional<peer::PeerInfo> self_announce);
+                                boost::optional<peer::PeerInfo> self_announce);
 
-  Message createPutValueRequest(const ContentAddress &key,
-                                Value value);
+  Message createPutValueRequest(const ContentAddress &key, Value value);
 
   Message createGetValueRequest(const ContentAddress &key);
 
-  Message createAddProviderRequest(peer::PeerInfo self, const ContentAddress &key);
+  Message createAddProviderRequest(peer::PeerInfo self,
+                                   const ContentAddress &key);
 
 }  // namespace libp2p::protocol::kademlia
 #endif  // LIBP2P_KAD_MESSAGE_HPP

--- a/src/crypto/crypto_provider/CMakeLists.txt
+++ b/src/crypto/crypto_provider/CMakeLists.txt
@@ -9,6 +9,7 @@ libp2p_add_library(p2p_crypto_provider
 
 target_link_libraries(p2p_crypto_provider
     p2p_crypto_error
+    p2p_ecdsa_provider
     p2p_ed25519_provider
     p2p_rsa_provider
     p2p_random_generator

--- a/src/crypto/crypto_provider/CMakeLists.txt
+++ b/src/crypto/crypto_provider/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(p2p_crypto_provider
     p2p_ed25519_provider
     p2p_rsa_provider
     p2p_random_generator
+    p2p_secp256k1_provider
     OpenSSL::Crypto
     Boost::filesystem
     )

--- a/src/crypto/crypto_provider/CMakeLists.txt
+++ b/src/crypto/crypto_provider/CMakeLists.txt
@@ -10,6 +10,7 @@ libp2p_add_library(p2p_crypto_provider
 target_link_libraries(p2p_crypto_provider
     p2p_crypto_error
     p2p_ed25519_provider
+    p2p_rsa_provider
     p2p_random_generator
     OpenSSL::Crypto
     Boost::filesystem

--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -351,7 +351,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<Buffer> CryptoProviderImpl::sign(
-      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+      gsl::span<const uint8_t> message, const PrivateKey &private_key) const {
     switch (private_key.type) {
       case Key::Type::RSA:
         return signRsa(message, private_key);
@@ -379,7 +379,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<Buffer> CryptoProviderImpl::signEd25519(
-      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+      gsl::span<const uint8_t> message, const PrivateKey &private_key) const {
     ed25519::PrivateKey priv_key;
     std::copy_n(private_key.data.begin(), priv_key.size(), priv_key.begin());
     OUTCOME_TRY(signature, ed25519_provider_->sign(message, priv_key));
@@ -387,7 +387,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<bool> CryptoProviderImpl::verify(
-      gsl::span<uint8_t> message, gsl::span<uint8_t> signature,
+      gsl::span<const uint8_t> message, gsl::span<const uint8_t> signature,
       const PublicKey &public_key) const {
     switch (public_key.type) {
       case Key::Type::RSA:
@@ -420,7 +420,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<bool> CryptoProviderImpl::verifyEd25519(
-      gsl::span<uint8_t> message, gsl::span<uint8_t> signature,
+      gsl::span<const uint8_t> message, gsl::span<const uint8_t> signature,
       const PublicKey &public_key) const {
     ed25519::PublicKey ed_pub;
     std::copy_n(public_key.data.begin(), ed_pub.size(), ed_pub.begin());

--- a/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
+++ b/src/crypto/ed25519_provider/ed25519_provider_impl.cpp
@@ -65,7 +65,7 @@ namespace libp2p::crypto::ed25519 {
   }
 
   outcome::result<Signature> Ed25519ProviderImpl::sign(
-      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+      gsl::span<const uint8_t> message, const PrivateKey &private_key) const {
     OUTCOME_TRY(evp_pkey,
                 NewEvpPkeyFromBytes(EVP_PKEY_ED25519, private_key,
                                     EVP_PKEY_new_raw_private_key));
@@ -93,7 +93,7 @@ namespace libp2p::crypto::ed25519 {
   }
 
   outcome::result<bool> Ed25519ProviderImpl::verify(
-      gsl::span<uint8_t> message, const Signature &signature,
+      gsl::span<const uint8_t> message, const Signature &signature,
       const PublicKey &public_key) const {
     OUTCOME_TRY(evp_pkey,
                 NewEvpPkeyFromBytes(EVP_PKEY_ED25519, public_key,

--- a/src/crypto/rsa_provider/CMakeLists.txt
+++ b/src/crypto/rsa_provider/CMakeLists.txt
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_library(p2p_rsa
+libp2p_add_library(p2p_rsa_provider
     rsa_provider_impl.cpp
     )
 
-target_link_libraries(p2p_rsa
+target_link_libraries(p2p_rsa_provider
     p2p_sha
     p2p_crypto_error
     OpenSSL::Crypto

--- a/src/crypto/rsa_provider/rsa_provider_impl.cpp
+++ b/src/crypto/rsa_provider/rsa_provider_impl.cpp
@@ -3,17 +3,104 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "libp2p/crypto/rsa_provider/rsa_provider_impl.hpp"
+#include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
 
-#include "libp2p/crypto/sha/sha256.hpp"
 #include <memory>
+
 #include <openssl/err.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
+#include <libp2p/crypto/sha/sha256.hpp>
 
 using Hash256 = libp2p::common::Hash256;
 
+namespace {
+  /// encode cryptographic key in `ASN.1 DER` format
+  template <class KeyStructure, class Function>
+  libp2p::outcome::result<std::vector<uint8_t>> encodeKeyDer(
+      KeyStructure *ks, Function *function) {
+    unsigned char *buffer = nullptr;
+    auto cleanup = gsl::finally([pptr = &buffer]() {
+      if (*pptr != nullptr) {
+        OPENSSL_free(*pptr);
+      }
+    });
+
+    int length = function(ks, &buffer);
+    if (length < 0) {
+      return libp2p::crypto::KeyGeneratorError::KEY_GENERATION_FAILED;
+    }
+
+    auto span = gsl::make_span(buffer, length);
+    return std::vector<uint8_t>{span.begin(), span.end()};
+  }
+}  // namespace
+
 namespace libp2p::crypto::rsa {
+
+  outcome::result<KeyPair> RsaProviderImpl::generate(
+      RSAKeyType rsa_bitness) const {
+    int bits{0};
+    switch (rsa_bitness) {
+      case RSAKeyType::RSA1024:
+        bits = 1024;
+        break;
+      case RSAKeyType::RSA4096:
+        bits = 4096;
+        break;
+      case RSAKeyType::RSA2048:
+      default:
+        bits = 2048;
+    }
+
+    int ret{0};
+    RSA *rsa{nullptr};
+    BIGNUM *bne{nullptr};
+    // clean up automatically
+    auto cleanup = gsl::finally([&]() {
+      if (nullptr != rsa) {
+        RSA_free(rsa);
+      }
+      if (nullptr != bne) {
+        BN_free(bne);
+      }
+    });
+
+    constexpr uint64_t exp = RSA_F4;
+
+    // 1. generate rsa state
+    bne = BN_new();
+    ret = BN_set_word(bne, exp);
+    if (ret != 1) {
+      return KeyGeneratorError::KEY_GENERATION_FAILED;
+    }
+
+    // 2. generate keys
+    rsa = RSA_new();
+    ret = RSA_generate_key_ex(rsa, bits, bne, nullptr);
+    if (ret != 1) {
+      return KeyGeneratorError::KEY_GENERATION_FAILED;
+    }
+
+    OUTCOME_TRY(private_bytes, encodeKeyDer(rsa, i2d_RSAPrivateKey));
+    OUTCOME_TRY(public_bytes, encodeKeyDer(rsa, i2d_RSA_PUBKEY));
+
+    return KeyPair{.private_key = private_bytes, .public_key = public_bytes};
+  }
+
+  outcome::result<PublicKey> RsaProviderImpl::derive(
+      const PrivateKey &private_key) const {
+    const unsigned char *data_pointer = private_key.data();
+    RSA *rsa = d2i_RSAPrivateKey(nullptr, &data_pointer, private_key.size());
+    if (nullptr == rsa) {
+      return KeyGeneratorError::KEY_DERIVATION_FAILED;
+    }
+    auto cleanup_rsa = gsl::finally([rsa]() { RSA_free(rsa); });
+
+    OUTCOME_TRY(public_bytes, encodeKeyDer(rsa, i2d_RSA_PUBKEY));
+
+    return std::move(public_bytes);
+  }
 
   outcome::result<std::shared_ptr<RSA>> rsaFromPrivateKey(
       const PrivateKey &private_key) {
@@ -28,7 +115,7 @@ namespace libp2p::crypto::rsa {
   }
 
   outcome::result<Signature> RsaProviderImpl::sign(
-      gsl::span<uint8_t> message, const PrivateKey &private_key) const {
+      gsl::span<const uint8_t> message, const PrivateKey &private_key) const {
     OUTCOME_TRY(rsa, rsaFromPrivateKey(private_key));
     Hash256 digest = sha256(message);
     Signature signature(RSA_size(rsa.get()));
@@ -42,16 +129,16 @@ namespace libp2p::crypto::rsa {
     return signature;
   }
 
-  outcome::result<bool> RsaProviderImpl::verify(gsl::span<uint8_t> message,
-                                                const Signature &signature,
-                                                const PublicKey &public_key) const {
+  outcome::result<bool> RsaProviderImpl::verify(
+      gsl::span<const uint8_t> message, const Signature &signature,
+      const PublicKey &public_key) const {
     OUTCOME_TRY(x509_key, RsaProviderImpl::getPublicKeyFromBytes(public_key));
     EVP_PKEY *key = X509_PUBKEY_get0(x509_key.get());
     std::unique_ptr<RSA, void (*)(RSA *)> rsa{EVP_PKEY_get1_RSA(key), RSA_free};
     Hash256 digest = sha256(message);
     int result = RSA_verify(NID_sha256, digest.data(), digest.size(),
                             signature.data(), signature.size(), rsa.get());
-    return result == 1 ? true : false;
+    return 1 == result;
   }
 
   outcome::result<std::shared_ptr<X509_PUBKEY>>

--- a/src/crypto/rsa_provider/rsa_provider_impl.cpp
+++ b/src/crypto/rsa_provider/rsa_provider_impl.cpp
@@ -38,6 +38,19 @@ namespace {
 
 namespace libp2p::crypto::rsa {
 
+  /**
+   * according to libp2p specification:
+   *  https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#how-keys-are-encoded-and-messages-signed
+   *  We encode the public key using the DER-encoded PKIX format
+   *  We encode the private key as a PKCS1 key using ASN.1 DER.
+   *
+   *  according to openssl manual:
+   *  https://www.openssl.org/docs/man1.1.1/man3/i2d_RSA_PUBKEY.html
+   *  d2i_RSA_PUBKEY() and i2d_RSA_PUBKEY() decode and encode a PKIX
+   *
+   *  https://www.openssl.org/docs/man1.1.1/man3/i2d_RSAPrivateKey.html
+   *  d2i_RSAPrivateKey(), i2d_RSAPrivateKey() decode and encode a PKCS#1
+   */
   outcome::result<KeyPair> RsaProviderImpl::generate(
       RSAKeyType rsa_bitness) const {
     int bits{0};

--- a/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
+++ b/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
@@ -10,12 +10,12 @@
 
 #include <memory>
 
+#include "libp2p/crypto/common_functions.hpp"
 #include "libp2p/crypto/error.hpp"
 #include "libp2p/crypto/sha/sha256.hpp"
-#include "libp2p/crypto/common_functions.hpp"
 
 namespace libp2p::crypto::secp256k1 {
-  outcome::result<KeyPair> Secp256k1ProviderImpl::generateKeyPair() const {
+  outcome::result<KeyPair> Secp256k1ProviderImpl::generate() const {
     PublicKey public_key{};
     PrivateKey private_key{};
     std::shared_ptr<EC_KEY> key{EC_KEY_new_by_curve_name(NID_secp256k1),
@@ -39,7 +39,7 @@ namespace libp2p::crypto::secp256k1 {
     return KeyPair{private_key, public_key};
   }
 
-  outcome::result<PublicKey> Secp256k1ProviderImpl::derivePublicKey(
+  outcome::result<PublicKey> Secp256k1ProviderImpl::derive(
       const PrivateKey &key) const {
     OUTCOME_TRY(private_key, bytesToPrivateKey(key));
     PublicKey public_key{};

--- a/src/protocol/kademlia/impl/kad_message.cpp
+++ b/src/protocol/kademlia/impl/kad_message.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #include <libp2p/multi/uvarint.hpp>
 #include <libp2p/protocol/kademlia/impl/kad_message.hpp>
 
@@ -24,8 +23,9 @@ namespace libp2p::protocol::kademlia {
       }
     }
 
-    std::optional<Message::Peer> assign_peer(const kad::pb::Message_Peer &src) {
-      using R = std::optional<Message::Peer>;
+    boost::optional<Message::Peer> assign_peer(
+        const kad::pb::Message_Peer &src) {
+      using R = boost::optional<Message::Peer>;
 
       if (int(src.connection()) > int(ConnStatus::CAN_NOT_CONNECT)) {
         // TODO(artem): log
@@ -54,7 +54,7 @@ namespace libp2p::protocol::kademlia {
     }
 
     template <class PbContainer>
-    bool assign_peers(std::optional<Message::Peers> &dst,
+    bool assign_peers(boost::optional<Message::Peers> &dst,
                       const PbContainer &src) {
       if (!src.empty()) {
         dst = Message::Peers{};
@@ -73,13 +73,13 @@ namespace libp2p::protocol::kademlia {
     }
 
     template <class PbContainer>
-    std::optional<Message::Record> assign_record(const PbContainer &src) {
+    boost::optional<Message::Record> assign_record(const PbContainer &src) {
       auto ca_res = ContentAddress::fromWire(src.key());
       if (!ca_res) {
         return {};
       }
-      std::optional<Message::Record> record = Message::Record
-          { std::move(ca_res.value()), Value(), src.timereceived() };
+      boost::optional<Message::Record> record = Message::Record{
+          std::move(ca_res.value()), Value(), src.timereceived()};
       assign_blob(record.value().value, src.value());
       return record;
     }
@@ -155,9 +155,8 @@ namespace libp2p::protocol::kademlia {
     size_t prefix_sz = varint_vec.size();
     buffer.resize(prefix_sz + msg_sz);
     memcpy(buffer.data(), varint_vec.data(), prefix_sz);
-    return pb_msg.SerializeToArray(
-        buffer.data() + prefix_sz, //NOLINT
-    msg_sz);
+    return pb_msg.SerializeToArray(buffer.data() + prefix_sz,  // NOLINT
+                                   msg_sz);
   }
 
   void Message::selfAnnounce(peer::PeerInfo self) {
@@ -166,7 +165,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   Message createFindNodeRequest(const peer::PeerId &node,
-                                std::optional<peer::PeerInfo> self_announce) {
+                                boost::optional<peer::PeerInfo> self_announce) {
     Message msg;
     msg.type = Message::kFindNode;
     msg.key = node.toVector();
@@ -177,7 +176,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   Message createAddProviderRequest(peer::PeerInfo self,
-      const ContentAddress &key) {
+                                   const ContentAddress &key) {
     Message msg;
     msg.type = Message::kAddProvider;
     msg.key = key.data;

--- a/src/protocol/kademlia/impl/kad_server.cpp
+++ b/src/protocol/kademlia/impl/kad_server.cpp
@@ -17,9 +17,10 @@ namespace libp2p::protocol::kademlia {
           &KadServer::onFindNode,    &KadServer::onPing};
 
   KadServer::KadServer(Host &host, KadImpl &kad)
-      : host_(host), kad_(kad), protocol_(kad_.config().protocolId),
-        log_("kad", "KadServer", &kad)
-  {
+      : host_(host),
+        kad_(kad),
+        protocol_(kad_.config().protocolId),
+        log_("kad", "KadServer", &kad) {
     host_.setProtocolHandler(protocol_,
                              [wptr = weak_from_this()](
                                  protocol::BaseProtocol::StreamResult rstream) {
@@ -36,14 +37,14 @@ namespace libp2p::protocol::kademlia {
   void KadServer::handle(StreamResult rstream) {
     if (!rstream) {
       log_.info("incoming connection failed due to '{}'",
-                 rstream.error().message());
+                rstream.error().message());
       return;
     }
 
     auto stream = rstream.value();
 
     log_.debug("incoming connection from '{}'",
-                stream->remoteMultiaddr().value().getStringAddress());
+               stream->remoteMultiaddr().value().getStringAddress());
 
     connection::Stream *s = stream.get();
     assert(sessions_.find(s) == sessions_.end());
@@ -72,7 +73,7 @@ namespace libp2p::protocol::kademlia {
       return;
 
     log_.debug("request from '{}', type = {}",
-                from->remoteMultiaddr().value().getStringAddress(), msg.type);
+               from->remoteMultiaddr().value().getStringAddress(), msg.type);
 
     bool close_session = (msg.type >= Message::kTableSize)
         || (not(this->*(request_handlers_table[msg.type]))(msg))  // NOLINT
@@ -91,7 +92,7 @@ namespace libp2p::protocol::kademlia {
     if (!session)
       return;
     log_.debug("server session completed, total sessions: {}",
-                sessions_.size() - 1);
+               sessions_.size() - 1);
     closeSession(from);
   }
 
@@ -104,12 +105,12 @@ namespace libp2p::protocol::kademlia {
   }
 
   bool KadServer::onPutValue(Message &msg) {
-    log_.info("{}",__FUNCTION__);
+    log_.info("{}", __FUNCTION__);
 
     if (!msg.record) {
       return false;
     }
-    auto& r = msg.record.value();
+    auto &r = msg.record.value();
 
     // TODO(artem): validate with external validator
 
@@ -118,11 +119,11 @@ namespace libp2p::protocol::kademlia {
       log_.info("onPutValue failed due to '{}'", res.error().message());
     }
 
-    return false; // no response
+    return false;  // no response
   }
 
   bool KadServer::onGetValue(Message &msg) {
-    log_.info("{}",__FUNCTION__);
+    log_.info("{}", __FUNCTION__);
 
     if (msg.key.empty()) {
       return false;
@@ -163,14 +164,15 @@ namespace libp2p::protocol::kademlia {
     LocalValueStore::AbsTime ts = 0;
     auto res = kad_.getLocalValueStore().getValue(cid, ts);
     if (res) {
-      msg.record = { std::move(cid), std::move(res.value()), std::to_string(ts) };
+      msg.record = Message::Record{std::move(cid), std::move(res.value()),
+                                   std::to_string(ts)};
     }
 
     return true;
   }
 
   bool KadServer::onAddProvider(Message &msg) {
-    log_.info("{}",__FUNCTION__);
+    log_.info("{}", __FUNCTION__);
 
     // TODO(artem): validate against sender id
 
@@ -179,16 +181,16 @@ namespace libp2p::protocol::kademlia {
     }
     ContentAddress cid(msg.key);
     auto providers = msg.provider_peers.value();
-    for (auto& p : providers) {
+    for (auto &p : providers) {
       kad_.getContentProvidersStore().addProvider(cid, p.info.id);
       kad_.addPeer(std::move(p.info), false);
     }
 
-    return false; // doesnt respond
+    return false;  // doesnt respond
   }
 
   bool KadServer::onGetProviders(Message &msg) {
-    log_.info("{}",__FUNCTION__);
+    log_.info("{}", __FUNCTION__);
 
     if (msg.key.empty()) {
       return false;
@@ -235,7 +237,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   bool KadServer::onFindNode(Message &msg) {
-    log_.info("{}",__FUNCTION__);
+    log_.info("{}", __FUNCTION__);
 
     if (msg.closer_peers) {
       for (auto &p : msg.closer_peers.value()) {
@@ -275,7 +277,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   bool KadServer::onPing(Message &msg) {
-    log_.info("{}",__FUNCTION__);
+    log_.info("{}", __FUNCTION__);
 
     if (msg.closer_peers) {
       for (auto &p : msg.closer_peers.value()) {

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -11,6 +11,7 @@
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
+#include <libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp>
 #include <libp2p/security/plaintext/exchange_message_marshaller_impl.hpp>
 #include "acceptance/p2p/host/peer/tick_counter.hpp"
 #include "acceptance/p2p/host/protocol/client_test_session.hpp"
@@ -27,9 +28,11 @@ Peer::Peer(Peer::Duration timeout)
           std::make_shared<crypto::ed25519::Ed25519ProviderImpl>()},
       rsa_provider_{std::make_shared<crypto::rsa::RsaProviderImpl>()},
       ecdsa_provider_{std::make_shared<crypto::ecdsa::EcdsaProviderImpl>()},
+      secp256k1_provider_{
+          std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>()},
       crypto_provider_{std::make_shared<crypto::CryptoProviderImpl>(
-          random_provider_, ed25519_provider_, rsa_provider_,
-          ecdsa_provider_)} {
+          random_provider_, ed25519_provider_, rsa_provider_, ecdsa_provider_,
+          secp256k1_provider_)} {
   EXPECT_OUTCOME_TRUE_MSG(
       keys, crypto_provider_->generateKeys(crypto::Key::Type::Ed25519),
       "failed to generate keys");
@@ -93,7 +96,8 @@ void Peer::wait() {
 
 Peer::sptr<host::BasicHost> Peer::makeHost(const crypto::KeyPair &keyPair) {
   auto crypto_provider = std::make_shared<crypto::CryptoProviderImpl>(
-      random_provider_, ed25519_provider_, rsa_provider_, ecdsa_provider_);
+      random_provider_, ed25519_provider_, rsa_provider_, ecdsa_provider_,
+      secp256k1_provider_);
 
   auto key_validator = std::make_shared<crypto::validator::KeyValidatorImpl>(
       std::move(crypto_provider));

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -6,6 +6,7 @@
 #include "acceptance/p2p/host/peer/test_peer.hpp"
 
 #include <gtest/gtest.h>
+#include <libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp>
 #include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
@@ -25,8 +26,10 @@ Peer::Peer(Peer::Duration timeout)
       ed25519_provider_{
           std::make_shared<crypto::ed25519::Ed25519ProviderImpl>()},
       rsa_provider_{std::make_shared<crypto::rsa::RsaProviderImpl>()},
+      ecdsa_provider_{std::make_shared<crypto::ecdsa::EcdsaProviderImpl>()},
       crypto_provider_{std::make_shared<crypto::CryptoProviderImpl>(
-          random_provider_, ed25519_provider_, rsa_provider_)} {
+          random_provider_, ed25519_provider_, rsa_provider_,
+          ecdsa_provider_)} {
   EXPECT_OUTCOME_TRUE_MSG(
       keys, crypto_provider_->generateKeys(crypto::Key::Type::Ed25519),
       "failed to generate keys");
@@ -90,7 +93,7 @@ void Peer::wait() {
 
 Peer::sptr<host::BasicHost> Peer::makeHost(const crypto::KeyPair &keyPair) {
   auto crypto_provider = std::make_shared<crypto::CryptoProviderImpl>(
-      random_provider_, ed25519_provider_, rsa_provider_);
+      random_provider_, ed25519_provider_, rsa_provider_, ecdsa_provider_);
 
   auto key_validator = std::make_shared<crypto::validator::KeyValidatorImpl>(
       std::move(crypto_provider));

--- a/test/acceptance/p2p/host/peer/test_peer.hpp
+++ b/test/acceptance/p2p/host/peer/test_peer.hpp
@@ -36,6 +36,7 @@ class Peer {
   using Ed25519Provider = libp2p::crypto::ed25519::Ed25519Provider;
   using RsaProvider = libp2p::crypto::rsa::RsaProvider;
   using EcdsaProvider = libp2p::crypto::ecdsa::EcdsaProvider;
+  using Secp256k1Provider = libp2p::crypto::secp256k1::Secp256k1Provider;
   using CryptoProvider = libp2p::crypto::CryptoProvider;
 
   using Context = boost::asio::io_context;
@@ -84,6 +85,7 @@ class Peer {
   sptr<Ed25519Provider> ed25519_provider_;      ///< ed25519 provider
   sptr<RsaProvider> rsa_provider_;              ///< rsa provider
   sptr<EcdsaProvider> ecdsa_provider_;          ///< ecdsa provider
+  sptr<Secp256k1Provider> secp256k1_provider_;  ///< secp256k1 provider
   sptr<CryptoProvider> crypto_provider_;        ///< crypto provider
 };
 

--- a/test/acceptance/p2p/host/peer/test_peer.hpp
+++ b/test/acceptance/p2p/host/peer/test_peer.hpp
@@ -35,6 +35,7 @@ class Peer {
   using BoostRandomGenerator = libp2p::crypto::random::BoostRandomGenerator;
   using Ed25519Provider = libp2p::crypto::ed25519::Ed25519Provider;
   using RsaProvider = libp2p::crypto::rsa::RsaProvider;
+  using EcdsaProvider = libp2p::crypto::ecdsa::EcdsaProvider;
   using CryptoProvider = libp2p::crypto::CryptoProvider;
 
   using Context = boost::asio::io_context;
@@ -82,6 +83,7 @@ class Peer {
   sptr<BoostRandomGenerator> random_provider_;  ///< random provider
   sptr<Ed25519Provider> ed25519_provider_;      ///< ed25519 provider
   sptr<RsaProvider> rsa_provider_;              ///< rsa provider
+  sptr<EcdsaProvider> ecdsa_provider_;          ///< ecdsa provider
   sptr<CryptoProvider> crypto_provider_;        ///< crypto provider
 };
 

--- a/test/acceptance/p2p/host/peer/test_peer.hpp
+++ b/test/acceptance/p2p/host/peer/test_peer.hpp
@@ -34,6 +34,7 @@ class Peer {
   using Echo = libp2p::protocol::Echo;
   using BoostRandomGenerator = libp2p::crypto::random::BoostRandomGenerator;
   using Ed25519Provider = libp2p::crypto::ed25519::Ed25519Provider;
+  using RsaProvider = libp2p::crypto::rsa::RsaProvider;
   using CryptoProvider = libp2p::crypto::CryptoProvider;
 
   using Context = boost::asio::io_context;
@@ -80,6 +81,7 @@ class Peer {
   sptr<Echo> echo_;                             ///< echo protocol
   sptr<BoostRandomGenerator> random_provider_;  ///< random provider
   sptr<Ed25519Provider> ed25519_provider_;      ///< ed25519 provider
+  sptr<RsaProvider> rsa_provider_;              ///< rsa provider
   sptr<CryptoProvider> crypto_provider_;        ///< crypto provider
 };
 

--- a/test/libp2p/crypto/CMakeLists.txt
+++ b/test/libp2p/crypto/CMakeLists.txt
@@ -65,7 +65,7 @@ addtest(rsa_provider_test
     rsa_provider_test.cpp
     )
 target_link_libraries(rsa_provider_test
-    p2p_rsa
+    p2p_rsa_provider
     )
 
 addtest(secp256k1_test

--- a/test/libp2p/crypto/ecdsa_provider_test.cpp
+++ b/test/libp2p/crypto/ecdsa_provider_test.cpp
@@ -5,8 +5,8 @@
 
 #include "libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp"
 
-#include <gsl/gsl_util>
 #include <gtest/gtest.h>
+#include <gsl/gsl_util>
 #include "testutil/outcome.hpp"
 
 using libp2p::crypto::ecdsa::EcdsaProviderImpl;
@@ -70,7 +70,7 @@ class EcdsaProviderTest : public ::testing::Test {
  * @then Derived public must be the same as the pre-generated
  */
 TEST_F(EcdsaProviderTest, DerivePublicKeySuccess) {
-  EXPECT_OUTCOME_TRUE(derived_key, provider_.DerivePublicKey(private_key_));
+  EXPECT_OUTCOME_TRUE(derived_key, provider_.derive(private_key_));
   ASSERT_EQ(public_key_, derived_key);
 }
 
@@ -80,12 +80,12 @@ TEST_F(EcdsaProviderTest, DerivePublicKeySuccess) {
  * @then Signature verification must be successful and signature must be valid
  */
 TEST_F(EcdsaProviderTest, SignVerifySuccess) {
-  EXPECT_OUTCOME_TRUE(key_pair, provider_.GenerateKeyPair());
+  EXPECT_OUTCOME_TRUE(key_pair, provider_.generate());
   EXPECT_OUTCOME_TRUE(signature,
-                      provider_.Sign(message_, key_pair.private_key));
+                      provider_.sign(message_, key_pair.private_key));
   EXPECT_OUTCOME_TRUE(
       verify_result,
-      provider_.Verify(message_, signature, key_pair.public_key));
+      provider_.verify(message_, signature, key_pair.public_key));
   ASSERT_TRUE(verify_result);
 }
 
@@ -96,7 +96,7 @@ TEST_F(EcdsaProviderTest, SignVerifySuccess) {
  */
 TEST_F(EcdsaProviderTest, SampleSignVerifySuccess) {
   EXPECT_OUTCOME_TRUE(verify_result,
-                      provider_.Verify(message_, signature_, public_key_));
+                      provider_.verify(message_, signature_, public_key_));
   ASSERT_TRUE(verify_result);
 }
 
@@ -106,10 +106,10 @@ TEST_F(EcdsaProviderTest, SampleSignVerifySuccess) {
  * @then Signature must be invalid
  */
 TEST_F(EcdsaProviderTest, VerifyInvalidPubKeyFailure) {
-  EXPECT_OUTCOME_TRUE(key_pair, provider_.GenerateKeyPair());
+  EXPECT_OUTCOME_TRUE(key_pair, provider_.generate());
   EXPECT_OUTCOME_TRUE(
       verify_result,
-      provider_.Verify(message_, signature_, key_pair.public_key));
+      provider_.verify(message_, signature_, key_pair.public_key));
   ASSERT_FALSE(verify_result);
 }
 
@@ -122,6 +122,6 @@ TEST_F(EcdsaProviderTest, VerifyInvalidMessageFailure) {
   std::array<uint8_t, 1> different_message{};
   EXPECT_OUTCOME_TRUE(
       verify_result,
-      provider_.Verify(different_message, signature_, public_key_));
+      provider_.verify(different_message, signature_, public_key_));
   ASSERT_FALSE(verify_result);
 }

--- a/test/libp2p/crypto/key_generator_test.cpp
+++ b/test/libp2p/crypto/key_generator_test.cpp
@@ -132,27 +132,8 @@ TEST_P(KeyLengthTest, KeyLengthCorrect) {
   ASSERT_EQ(val.privateKey.data.size(), private_key_length);
 }
 
-// TODO(turuslan): convert to TestWithParam and test more key types
-class KeyGoCompatibility : public ::testing::Test {
- public:
-  KeyGoCompatibility()
-      : random_{std::make_shared<BoostRandomGenerator>()},
-        ed25519_provider_{std::make_shared<Ed25519ProviderImpl>()},
-        rsa_provider_{std::make_shared<RsaProviderImpl>()},
-        ecdsa_provider_{std::make_shared<EcdsaProviderImpl>()},
-        secp256k1_provider_{std::make_shared<Secp256k1ProviderImpl>()},
-        crypto_provider_{std::make_shared<CryptoProviderImpl>(
-            random_, ed25519_provider_, rsa_provider_, ecdsa_provider_,
-            secp256k1_provider_)} {}
-
- protected:
-  std::shared_ptr<CSPRNG> random_;
-  std::shared_ptr<Ed25519Provider> ed25519_provider_;
-  std::shared_ptr<RsaProvider> rsa_provider_;
-  std::shared_ptr<EcdsaProvider> ecdsa_provider_;
-  std::shared_ptr<Secp256k1Provider> secp256k1_provider_;
-  std::shared_ptr<CryptoProvider> crypto_provider_;
-};
+// TODO(turuslan): FIL-132 convert to TestWithParam and test more key types
+class KeyGoCompatibility : public KeyGenTest, public ::testing::Test {};
 
 TEST_F(KeyGoCompatibility, RSA_old) {
   PrivateKey privateKey{

--- a/test/libp2p/crypto/key_generator_test.cpp
+++ b/test/libp2p/crypto/key_generator_test.cpp
@@ -13,6 +13,7 @@
 #include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/error.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
+#include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
 #include <testutil/outcome.hpp>
 
 using libp2p::common::ByteArray;
@@ -25,6 +26,8 @@ using libp2p::crypto::ed25519::Ed25519Provider;
 using libp2p::crypto::ed25519::Ed25519ProviderImpl;
 using libp2p::crypto::random::BoostRandomGenerator;
 using libp2p::crypto::random::CSPRNG;
+using libp2p::crypto::rsa::RsaProvider;
+using libp2p::crypto::rsa::RsaProviderImpl;
 using libp2p::common::operator""_unhex;
 using libp2p::common::operator""_v;
 
@@ -33,12 +36,14 @@ class KeyGeneratorTest : public ::testing::TestWithParam<Key::Type> {
   KeyGeneratorTest()
       : random_{std::make_shared<BoostRandomGenerator>()},
         ed25519_provider_{std::make_shared<Ed25519ProviderImpl>()},
-        crypto_provider_{
-            std::make_shared<CryptoProviderImpl>(random_, ed25519_provider_)} {}
+        rsa_provider_{std::make_shared<RsaProviderImpl>()},
+        crypto_provider_{std::make_shared<CryptoProviderImpl>(
+            random_, ed25519_provider_, rsa_provider_)} {}
 
  protected:
   std::shared_ptr<CSPRNG> random_;
   std::shared_ptr<Ed25519Provider> ed25519_provider_;
+  std::shared_ptr<RsaProvider> rsa_provider_;
   std::shared_ptr<CryptoProvider> crypto_provider_;
 };
 
@@ -49,10 +54,6 @@ class KeyGeneratorTest : public ::testing::TestWithParam<Key::Type> {
  */
 TEST_P(KeyGeneratorTest, GenerateKeyPairSuccess) {
   auto key_type = GetParam();
-  if (key_type == Key::Type::RSA) {
-    return;
-  }
-
   EXPECT_OUTCOME_TRUE_2(val, crypto_provider_->generateKeys(key_type))
   ASSERT_EQ(val.privateKey.type, key_type);
   ASSERT_EQ(val.publicKey.type, key_type);
@@ -65,10 +66,6 @@ TEST_P(KeyGeneratorTest, GenerateKeyPairSuccess) {
  */
 TEST_P(KeyGeneratorTest, TwoKeysAreDifferent) {
   auto key_type = GetParam();
-  if (key_type == Key::Type::RSA) {
-    return;
-  }
-
   EXPECT_OUTCOME_TRUE_2(val1, crypto_provider_->generateKeys(key_type));
   EXPECT_OUTCOME_TRUE_2(val2, crypto_provider_->generateKeys(key_type));
   ASSERT_NE(val1.privateKey.data, val2.privateKey.data);
@@ -84,9 +81,6 @@ TEST_P(KeyGeneratorTest, TwoKeysAreDifferent) {
  */
 TEST_P(KeyGeneratorTest, DerivePublicKeySuccess) {
   auto key_type = GetParam();
-  if (key_type == Key::Type::RSA) {
-    return;
-  }
 
   EXPECT_OUTCOME_TRUE_2(keys, crypto_provider_->generateKeys(key_type));
   EXPECT_OUTCOME_TRUE_2(derived,
@@ -107,12 +101,14 @@ class KeyLengthTest
   KeyLengthTest()
       : random_{std::make_shared<BoostRandomGenerator>()},
         ed25519_provider_{std::make_shared<Ed25519ProviderImpl>()},
-        crypto_provider_{
-            std::make_shared<CryptoProviderImpl>(random_, ed25519_provider_)} {}
+        rsa_provider_{std::make_shared<RsaProviderImpl>()},
+        crypto_provider_{std::make_shared<CryptoProviderImpl>(
+            random_, ed25519_provider_, rsa_provider_)} {}
 
  protected:
   std::shared_ptr<CSPRNG> random_;
   std::shared_ptr<Ed25519Provider> ed25519_provider_;
+  std::shared_ptr<RsaProvider> rsa_provider_;
   std::shared_ptr<CryptoProvider> crypto_provider_;
 };
 
@@ -141,25 +137,48 @@ class KeyGoCompatibility : public ::testing::Test {
   KeyGoCompatibility()
       : random_{std::make_shared<BoostRandomGenerator>()},
         ed25519_provider_{std::make_shared<Ed25519ProviderImpl>()},
-        crypto_provider_{
-            std::make_shared<CryptoProviderImpl>(random_, ed25519_provider_)} {}
+        rsa_provider_{std::make_shared<RsaProviderImpl>()},
+        crypto_provider_{std::make_shared<CryptoProviderImpl>(
+            random_, ed25519_provider_, rsa_provider_)} {}
 
  protected:
   std::shared_ptr<CSPRNG> random_;
   std::shared_ptr<Ed25519Provider> ed25519_provider_;
+  std::shared_ptr<RsaProvider> rsa_provider_;
   std::shared_ptr<CryptoProvider> crypto_provider_;
 };
 
-TEST_F(KeyGoCompatibility, RSA) {
+TEST_F(KeyGoCompatibility, RSA_old) {
   PrivateKey privateKey{
       {Key::Type::RSA,
-       "3082025e02010002818100bcaf3ee0f2bc3ac58ab3fcb3c23b2386230564331653ae34e9e09ea6fb0b9cfcf9c6ef76c9337d9b8ed29b4505c8e57a06a9a008ecb89ece3a6e809af64342be4367e06ba1bec131c8944465ba1f5cead836e84932097aea1f6aefc97e84f76219b9dec8afd7a1d0fa90802bd84b1d021112daf026c60ad958db4247e56dc39d0203010001028180407fdb8bc40e6a3ccafc59ff0cff705653346d9b351fa7e678a88b33639005bb489b2392c496b07273b134d8b47087595e5bafd43d2fa341b621be1ebade253b149ba6df498b94269b708547406aeb5da7d71e4fa52fff331cfbae3db55c51ed896d914e93bc0a703aaafed6fe83e7f9af20c2fcfd7207d34426b6b4ed8283b5024100e678fb31b2489505bdb0cf16c23fd6e4ff5069de71f72c12e5a1b0c295aa4fa6e2b691fd5c5ea98473d0884dd969a258f48e5593bdc15f8c72f9da775ca0aeff024100d1955ed85222b96e55e1f9d7865dcb78467a12839f0a3f5b17791b15a1d5b14c20e96bb6d352988f628030282a1c44027e168bb79dac7eb858c1bb3c6ffce963024100d298a808203dfc96336055cb1912d69d87c3060a729f0651fa2cc664f7f7993308a5053fbb60f08b8c7c77a09352d83b6ab488f428878374c63712eed0e02f27024100b94ed2ef7da00a488e5321aef8b511e4a49be6a6ce062782893ca13ffd398e6bfb65a7c19d1398a49eb92cdb36708b8990a6aa9e8d21296221c8199f147d9075024100a7abd450a0c8fe8f3cb2c0d8fca3f15094b512dce328ce543977c14f80dcb7e41ac4ae7fb2925fae724b6e2494231d0c51572ae89510b4ce6e984623ddf2c923"_unhex}};
+       "3082025e02010002818100bcaf3ee0f2bc3ac58ab3fcb3c23b2386230564331653ae34e"
+       "9e09ea6fb0b9cfcf9c6ef76c9337d9b8ed29b4505c8e57a06a9a008ecb89ece3a6e809a"
+       "f64342be4367e06ba1bec131c8944465ba1f5cead836e84932097aea1f6aefc97e84f76"
+       "219b9dec8afd7a1d0fa90802bd84b1d021112daf026c60ad958db4247e56dc39d020301"
+       "0001028180407fdb8bc40e6a3ccafc59ff0cff705653346d9b351fa7e678a88b3363900"
+       "5bb489b2392c496b07273b134d8b47087595e5bafd43d2fa341b621be1ebade253b149b"
+       "a6df498b94269b708547406aeb5da7d71e4fa52fff331cfbae3db55c51ed896d914e93b"
+       "c0a703aaafed6fe83e7f9af20c2fcfd7207d34426b6b4ed8283b5024100e678fb31b248"
+       "9505bdb0cf16c23fd6e4ff5069de71f72c12e5a1b0c295aa4fa6e2b691fd5c5ea98473d"
+       "0884dd969a258f48e5593bdc15f8c72f9da775ca0aeff024100d1955ed85222b96e55e1"
+       "f9d7865dcb78467a12839f0a3f5b17791b15a1d5b14c20e96bb6d352988f628030282a1"
+       "c44027e168bb79dac7eb858c1bb3c6ffce963024100d298a808203dfc96336055cb1912"
+       "d69d87c3060a729f0651fa2cc664f7f7993308a5053fbb60f08b8c7c77a09352d83b6ab"
+       "488f428878374c63712eed0e02f27024100b94ed2ef7da00a488e5321aef8b511e4a49b"
+       "e6a6ce062782893ca13ffd398e6bfb65a7c19d1398a49eb92cdb36708b8990a6aa9e8d2"
+       "1296221c8199f147d9075024100a7abd450a0c8fe8f3cb2c0d8fca3f15094b512dce328"
+       "ce543977c14f80dcb7e41ac4ae7fb2925fae724b6e2494231d0c51572ae89510b4ce6e9"
+       "84623ddf2c923"_unhex}};
 
   auto derivedPublicKey = crypto_provider_->derivePublicKey(privateKey).value();
 
   EXPECT_EQ(
       derivedPublicKey.data,
-      "30819f300d06092a864886f70d010101050003818d0030818902818100bcaf3ee0f2bc3ac58ab3fcb3c23b2386230564331653ae34e9e09ea6fb0b9cfcf9c6ef76c9337d9b8ed29b4505c8e57a06a9a008ecb89ece3a6e809af64342be4367e06ba1bec131c8944465ba1f5cead836e84932097aea1f6aefc97e84f76219b9dec8afd7a1d0fa90802bd84b1d021112daf026c60ad958db4247e56dc39d0203010001"_unhex);
+      "30819f300d06092a864886f70d010101050003818d0030818902818100bcaf3ee0"
+      "f2bc3ac58ab3fcb3c23b2386230564331653ae34e9e09ea6fb0b9cfcf9c6ef76c9"
+      "337d9b8ed29b4505c8e57a06a9a008ecb89ece3a6e809af64342be4367e06ba1be"
+      "c131c8944465ba1f5cead836e84932097aea1f6aefc97e84f76219b9dec8afd7a1"
+      "d0fa90802bd84b1d021112daf026c60ad958db4247e56dc39d0203010001"_unhex);
 }
 
 TEST_F(KeyGoCompatibility, ECDSA) {
@@ -174,6 +193,11 @@ TEST_F(KeyGoCompatibility, ECDSA) {
       "033571844d75a74a49a3b5e2953261078ff60cacd270cab134c8b70ded6d26e5cd"_unhex);
 }
 
+/**
+ * @given a private Ed25519 key generated in golang
+ * @when public key derived, test blob signed and signature gets verified
+ * @then all the outcomes are the same as in golang
+ */
 TEST_F(KeyGoCompatibility, Ed25519) {
   PrivateKey private_key{
       {Key::Type::Ed25519,
@@ -195,6 +219,83 @@ TEST_F(KeyGoCompatibility, Ed25519) {
       signature,
       "575304fbd0f8096439ca18e588beffc67218e3d117a14cb41cecf3bc180f9496"
       "90e5be626ae678a23ac5dfcccc516acc0527f67e0f0a696525a31d667305d406"_unhex);
+
+  auto verify_result =
+      crypto_provider_->verify(msg_span, signature, derived).value();
+  ASSERT_TRUE(verify_result);
+}
+
+/**
+ * @given a private RSA2048 key generated in golang
+ * @when public key derived, test blob signed and signature gets verified
+ * @then all the outcomes are the same as in golang
+ */
+TEST_F(KeyGoCompatibility, RSA) {
+  PrivateKey private_key{
+      {Key::Type::RSA,
+       "308204a30201000282010100d29170cf0ebe339eb4b4ec2a7642246f8f1566af0df6e1c"
+       "9de79219b31ac97dca32ef9fa265fb46c7ad91098eec3cfc1e31df407ed6a5a0a2f1979"
+       "01dbf232ad8d5e57dd47fe29ed423b3a8415fac698e982b8e0a32ac857e44591bbdef51"
+       "26a9a621efe7267b1e5f6db02f86c217c9266c8faed612723e593a0364650f5e4103053"
+       "63f4f08209c912edaea15173277b68ab6d057282143f9b66dd13d518265d0642f494e03"
+       "16a52bac226b2783a7b10905a6e793a14d9c9d065b3847d7eab44f5c4c3f838468b020f"
+       "6f2fe55fa07ade60b5007ca398ba33910954a901bde2b34932c7c759681d6bbef3e692c"
+       "0397200edf21585be7224e3a3daaf55b6879f7f02030100010282010038c444e94d4c31"
+       "96639932e1efa7bd32e61c1ae6ae99141ddc0043f316dd34c3a2aa9371c0cea4516a7d0"
+       "260785e09b0778e27afcb6d9480925a07a95ca65acb37056c2297ba098b91036eaf154d"
+       "da24772f6ab004cd0fddc2088f555ab22f18d62e05b50b1ab17711a9d18f2f7787a1e05"
+       "be66a007b10ce5f921d8faf5bdaf394bbb68b5c582edac264cc3eeef893191b6e4e2cb0"
+       "60d87b3f6efa90423ce513c8fae23c7d4938378ab9488512f7b340a9aedd1f6d236c01a"
+       "df16bf8de79c3255d9a70e6aa051ddcb248b9e79ec4b9cb3f16e63670009cdc6df31912"
+       "c6644c9ef492e79ab3298a15ab4cfa68525ade5cb82742c6fe7bb0482c9dd570f8e8002"
+       "102818100fbb1c859459a9705dcd6b5600053ad646dfff28edb87cf53ccddff39b522b2"
+       "e21d4dc44f1f4d1726bda52ba83246117d42577bff46a2a2af66c4cea6ff3f215864649"
+       "17b6895b552d6859771577328c250ed430593447405386e5b263dd882bcd3a7396c5631"
+       "21ed1718cfdd2f138faf66fda35643973b65a9f22e4d9146e29302818100d62b8edeea3"
+       "3627de02504e8983e92008348fc1257f484d8e9ea9cd597aede49625743c16274279393"
+       "277b61f891da11007880c9ab12cccaddbb2ddbe4904efe599f82479049bab5309a989f4"
+       "23eee89d232a74e498c220ee4681a0e55e7c3f36d93f517739776d731fd337ed7fbf859"
+       "32f96350c994be3314e33336302286e50281803772f5366595270c4d98a7a09cb1d2933"
+       "b8095894f67de0f12251e23327a907a2c0683e70278534f5f9c51bfde437d7ae0f0b10a"
+       "8e1f2a440619f984e4da9d980195fe4ef7bd7392ea5bc7ff5a4aae82109e1493d7dbcec"
+       "b8fa110479e7c62610327e608adfc6902f881a8d98b937da620c464058f22741d73913d"
+       "0e2da1362d0281804ce4f2b4e24d74ad510eb9867132f5e4ad3e4512a8f5a7c4e1a7548"
+       "bf39bdb3f69c97f102db31a8a87a90349979f7635e87f5b6e0cb801434cfce9682bd60c"
+       "2692330ce978ca9ff871ecefa32e7bbdd549dcd9e8e7cb22674a667e046b9f7ce127949"
+       "9c8c3bdbbf363854f39d97e241a928cabb5d3ca4dc7b556258aed19586902818100af71"
+       "a0b0a23c0f0a79549291b705b7a51234d73b54db0339ff727b8669af76a3be1030b40ae"
+       "4ffd8ebc593913d7d80b3e16a67c2433bd627f2d47adb3f3cbaf2326f119f8986384c11"
+       "390bc89da38f275c62659f799d21063833caeaed03b10a8433ab6cb6705f854d026959f"
+       "69b2248488fcf5287ab86715dbc0974325756f2"_unhex}};
+
+  auto derived = crypto_provider_->derivePublicKey(private_key).value();
+  EXPECT_EQ(
+      derived.data,
+      "30820122300d06092a864886f70d01010105000382010f003082010a0282010100"
+      "d29170cf0ebe339eb4b4ec2a7642246f8f1566af0df6e1c9de79219b31ac97dca3"
+      "2ef9fa265fb46c7ad91098eec3cfc1e31df407ed6a5a0a2f197901dbf232ad8d5e"
+      "57dd47fe29ed423b3a8415fac698e982b8e0a32ac857e44591bbdef5126a9a621e"
+      "fe7267b1e5f6db02f86c217c9266c8faed612723e593a0364650f5e410305363f4"
+      "f08209c912edaea15173277b68ab6d057282143f9b66dd13d518265d0642f494e0"
+      "316a52bac226b2783a7b10905a6e793a14d9c9d065b3847d7eab44f5c4c3f83846"
+      "8b020f6f2fe55fa07ade60b5007ca398ba33910954a901bde2b34932c7c759681d"
+      "6bbef3e692c0397200edf21585be7224e3a3daaf55b6879f7f0203010001"_unhex);
+
+  auto message{"think of the rapture!"_v};
+  const size_t message_len{21};  // here we do not count terminating null char
+  ASSERT_EQ(message.size(), message_len);
+
+  auto msg_span = gsl::make_span(message.data(), message_len);
+  auto signature = crypto_provider_->sign(msg_span, private_key).value();
+  EXPECT_EQ(signature,
+            "23127a1173417488c13366c5af09a66699eae8c36a8ce6d2a355b9cadaf35cf02a"
+            "5f040c8e5abb2a03d99306060557f2d160b6cc5ba0af72013aae91afc1d7b26a57"
+            "2ca25c46e8b80c71a8ba797acca66d339c2dd99ef77fba9d67b475973c016260b5"
+            "6b50ec78b2e1cb584ca6c86a9917564c7452330bc8ff4bbe9444d4fb77f5607220"
+            "3ae51d8e4bff3d561d3878f2adedeb91e5c7c6bf63e3ccca0250a9729c5cea64ae"
+            "34bc9f23fcdeae0dde9025558f5eec52f7c28605dc570e8ffe123642255cbb6cff"
+            "a966984a1b403976947e08a914f3a243c0c2bbba07c703ea444caf81dff8f22fd5"
+            "77ee81f40e0697066d1f80ff41428a83f0c5b5b6045ce13dc6"_unhex);
 
   auto verify_result =
       crypto_provider_->verify(msg_span, signature, derived).value();

--- a/test/libp2p/crypto/key_validator_test.cpp
+++ b/test/libp2p/crypto/key_validator_test.cpp
@@ -13,6 +13,7 @@
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
 #include <libp2p/crypto/rsa_provider/rsa_provider_impl.hpp>
+#include <libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp>
 #include <testutil/outcome.hpp>
 
 using ::testing::_;
@@ -35,6 +36,8 @@ using libp2p::crypto::random::BoostRandomGenerator;
 using libp2p::crypto::random::CSPRNG;
 using libp2p::crypto::rsa::RsaProvider;
 using libp2p::crypto::rsa::RsaProviderImpl;
+using libp2p::crypto::secp256k1::Secp256k1Provider;
+using libp2p::crypto::secp256k1::Secp256k1ProviderImpl;
 using libp2p::crypto::validator::KeyValidator;
 using libp2p::crypto::validator::KeyValidatorImpl;
 
@@ -44,8 +47,11 @@ struct BaseKeyTest {
       std::make_shared<Ed25519ProviderImpl>();
   std::shared_ptr<RsaProvider> rsa = std::make_shared<RsaProviderImpl>();
   std::shared_ptr<EcdsaProvider> ecdsa = std::make_shared<EcdsaProviderImpl>();
+  std::shared_ptr<Secp256k1Provider> secp256k1 =
+      std::make_shared<Secp256k1ProviderImpl>();
   std::shared_ptr<CryptoProvider> crypto_provider =
-      std::make_shared<CryptoProviderImpl>(random, ed25519, rsa, ecdsa);
+      std::make_shared<CryptoProviderImpl>(random, ed25519, rsa, ecdsa,
+                                           secp256k1);
   std::shared_ptr<KeyValidator> validator =
       std::make_shared<KeyValidatorImpl>(crypto_provider);
 };

--- a/test/libp2p/crypto/key_validator_test.cpp
+++ b/test/libp2p/crypto/key_validator_test.cpp
@@ -8,6 +8,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <libp2p/crypto/crypto_provider/crypto_provider_impl.hpp>
+#include <libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp>
 #include <libp2p/crypto/ed25519_provider/ed25519_provider_impl.hpp>
 #include <libp2p/crypto/key_validator/key_validator_impl.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
@@ -26,6 +27,8 @@ using libp2p::crypto::Key;
 using libp2p::crypto::KeyPair;
 using libp2p::crypto::PrivateKey;
 using libp2p::crypto::PublicKey;
+using libp2p::crypto::ecdsa::EcdsaProvider;
+using libp2p::crypto::ecdsa::EcdsaProviderImpl;
 using libp2p::crypto::ed25519::Ed25519Provider;
 using libp2p::crypto::ed25519::Ed25519ProviderImpl;
 using libp2p::crypto::random::BoostRandomGenerator;
@@ -40,8 +43,9 @@ struct BaseKeyTest {
   std::shared_ptr<Ed25519Provider> ed25519 =
       std::make_shared<Ed25519ProviderImpl>();
   std::shared_ptr<RsaProvider> rsa = std::make_shared<RsaProviderImpl>();
+  std::shared_ptr<EcdsaProvider> ecdsa = std::make_shared<EcdsaProviderImpl>();
   std::shared_ptr<CryptoProvider> crypto_provider =
-      std::make_shared<CryptoProviderImpl>(random, ed25519, rsa);
+      std::make_shared<CryptoProviderImpl>(random, ed25519, rsa, ecdsa);
   std::shared_ptr<KeyValidator> validator =
       std::make_shared<KeyValidatorImpl>(crypto_provider);
 };

--- a/test/libp2p/crypto/secp256k1_test.cpp
+++ b/test/libp2p/crypto/secp256k1_test.cpp
@@ -5,8 +5,8 @@
 #include <algorithm>
 
 #include <gtest/gtest.h>
-#include "testutil/outcome.hpp"
 #include "libp2p/crypto/secp256k1_provider/secp256k1_provider_impl.hpp"
+#include "testutil/outcome.hpp"
 
 using libp2p::crypto::secp256k1::PrivateKey;
 using libp2p::crypto::secp256k1::PublicKey;
@@ -60,8 +60,7 @@ class Secp256k1ProviderTest : public ::testing::Test {
  */
 TEST_F(Secp256k1ProviderTest, PublicKeyDerivationSuccess) {
   Secp256k1ProviderImpl provider;
-  EXPECT_OUTCOME_TRUE(derivedPublicKey,
-                      provider.derivePublicKey(sample_private_key_));
+  EXPECT_OUTCOME_TRUE(derivedPublicKey, provider.derive(sample_private_key_));
   ASSERT_EQ(derivedPublicKey, sample_public_key_);
 };
 
@@ -83,7 +82,7 @@ TEST_F(Secp256k1ProviderTest, PreGeneratedSignatureVerificationSuccess) {
  * @then Generating key pair, signature and it's verification must be successful
  */
 TEST_F(Secp256k1ProviderTest, GenerateSignatureSuccess) {
-  EXPECT_OUTCOME_TRUE(keyPair, provider_.generateKeyPair());
+  EXPECT_OUTCOME_TRUE(keyPair, provider_.generate());
   EXPECT_OUTCOME_TRUE(signature, provider_.sign(message_, keyPair.private_key));
   EXPECT_OUTCOME_TRUE(
       verificationResult,
@@ -97,8 +96,8 @@ TEST_F(Secp256k1ProviderTest, GenerateSignatureSuccess) {
  * @then Signature for different public key must be invalid
  */
 TEST_F(Secp256k1ProviderTest, VerifySignatureInvalidKeyFailure) {
-  EXPECT_OUTCOME_TRUE(firstKeyPair, provider_.generateKeyPair());
-  EXPECT_OUTCOME_TRUE(secondKeyPair, provider_.generateKeyPair());
+  EXPECT_OUTCOME_TRUE(firstKeyPair, provider_.generate());
+  EXPECT_OUTCOME_TRUE(secondKeyPair, provider_.generate());
   EXPECT_OUTCOME_TRUE(signature,
                       provider_.sign(message_, firstKeyPair.private_key));
   EXPECT_OUTCOME_TRUE(


### PR DESCRIPTION
Use standalone crypto providers as dependencies of a general crypto provider.
Use stronger types in crypto providers' interfaces.
Enable all RSA tests.

This pr will enable all crypto provider implementations for SECIO.

## Possible Drawbacks

For consistency purposes, in a couple of crypto providers - methods generate and derive were renamed. That may cause changes in Filecoin project if some of crypto providers are used there.

```diff
-generateKeyPair
+generate

-derivePublicKey
+derive
```

## Tests

```
rsa_provider_test
secp256k1_test
ecdsa_test
keygen_test
key_validator_test
```