### PR TITLE
Convert CID to string representation

### DIFF
--- a/include/libp2p/multi/content_identifier.hpp
+++ b/include/libp2p/multi/content_identifier.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <boost/operators.hpp>
+#include <libp2p/multi/multibase_codec.hpp>
 #include <libp2p/multi/multicodec_type.hpp>
 #include <libp2p/multi/multihash.hpp>
 
@@ -36,7 +37,7 @@ namespace libp2p::multi {
      * @param base is a human-readable multibase prefix
      * @returns human readable representation of the CID
      */
-    std::string toPrettyString(const std::string &base);
+    std::string toPrettyString(const std::string &base) const;
 
     bool operator==(const ContentIdentifier &c) const;
     bool operator<(const ContentIdentifier &c) const;

--- a/include/libp2p/multi/content_identifier_codec.hpp
+++ b/include/libp2p/multi/content_identifier_codec.hpp
@@ -7,6 +7,7 @@
 #define LIBP2P_CONTENT_IDENTIFIER_CODEC_HPP
 
 #include <libp2p/multi/content_identifier.hpp>
+#include <libp2p/multi/multibase_codec/codecs/base58.hpp>
 
 namespace libp2p::multi {
 
@@ -20,7 +21,8 @@ namespace libp2p::multi {
     enum class EncodeError {
       INVALID_CONTENT_TYPE = 1,
       INVALID_HASH_TYPE,
-      INVALID_HASH_LENGTH
+      INVALID_HASH_LENGTH,
+      VERSION_UNSUPPORTED
     };
 
     enum class DecodeError {
@@ -39,6 +41,18 @@ namespace libp2p::multi {
 
     static outcome::result<ContentIdentifier> decode(
         gsl::span<const uint8_t> bytes);
+
+    /**
+     * @brief Encode CID v0 to string representation
+     * @param cid - input CID for encode
+     * @param encoding - type of the encoding, ignored for CID v0 (always
+     * Base58)
+     * @todo Sergey Kaprovich: FIL-133 add support for CID v1
+     * @return CID string
+     */
+    static outcome::result<std::string> toString(
+        const ContentIdentifier &cid,
+        MultibaseCodec::Encoding encoding = MultibaseCodec::Encoding::BASE58);
   };
 
 }  // namespace libp2p::multi

--- a/src/multi/CMakeLists.txt
+++ b/src/multi/CMakeLists.txt
@@ -42,4 +42,5 @@ target_link_libraries(p2p_cid
     p2p_multihash
     p2p_sha
     p2p_uvarint
+    p2p_multibase_codec
     )

--- a/src/multi/content_identifier.cpp
+++ b/src/multi/content_identifier.cpp
@@ -17,7 +17,7 @@ namespace libp2p::multi {
         content_type{content_type},
         content_address{std::move(content_address)} {}
 
-  std::string ContentIdentifier::toPrettyString(const std::string &base) {
+  std::string ContentIdentifier::toPrettyString(const std::string &base) const {
     /// TODO(Harrm) FIL-14: hash type is a subset of multicodec type, better move them
     /// to one place
     std::string hash_type = MulticodecType::getName(

--- a/src/multi/content_identifier_codec.cpp
+++ b/src/multi/content_identifier_codec.cpp
@@ -20,6 +20,8 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::multi, ContentIdentifierCodec::EncodeError,
       return "Hash length is invalid; Must be 32 bytes for sha256 in version 0";
     case E::INVALID_HASH_TYPE:
       return "Hash type is invalid; Must be sha256 in version 0";
+    case E::VERSION_UNSUPPORTED:
+      return "Content identifier version unsupported";
   }
   return "Unknown error";
 }
@@ -114,5 +116,20 @@ namespace libp2p::multi {
       return DecodeError::MALFORMED_VERSION;
     }
     return DecodeError::RESERVED_VERSION;
+  }
+
+  outcome::result<std::string> ContentIdentifierCodec::toString(
+      const ContentIdentifier &cid, MultibaseCodec::Encoding encoding) {
+    std::ignore = encoding;
+    std::string result;
+    OUTCOME_TRY(cid_bytes, encode(cid));
+    switch (cid.version) {
+      case ContentIdentifier::Version::V0:
+        result = detail::encodeBase58(cid_bytes);
+        break;
+      default:
+        return EncodeError::VERSION_UNSUPPORTED;
+    }
+    return result;
   }
 }  // namespace libp2p::multi

--- a/test/libp2p/multi/cid_test.cpp
+++ b/test/libp2p/multi/cid_test.cpp
@@ -44,6 +44,21 @@ TEST(CidTest, PrettyString) {
 }
 
 /**
+ * @given CID with sample multihash and it's string representation from
+ * reference implementation tests
+ * @when Convert given CID to string
+ * @then Generated and reference string representations must be equal
+ */
+TEST(CidTest, MultibaseStringSuccess) {
+  const Multihash reference_multihash =
+      "12209658BF8A26B986DEE4ACEB8227B6A74D638CE4CDB2D72CD19516A6F83F1BFDD3"_multihash;
+  ContentIdentifier cid(ContentIdentifier::Version::V0, MulticodecType::DAG_PB,
+                        reference_multihash);
+  EXPECT_OUTCOME_TRUE(cid_string, ContentIdentifierCodec::toString(cid))
+  ASSERT_EQ(cid_string, "QmYTYMTdkVyB8we45bdXfZuDu5vCjRVX8QNTFLhC7K8C7t");
+}
+
+/**
  * @given CID of different versions
  * @when compare CIDs
  * @then lesser version is always less


### PR DESCRIPTION
Convert CID to string, e.g. `QmYTYMTdkVyB8we45bdXfZuDu5vCjRVX8QNTFLhC7K8C7t`

This implementation supports only **CID V0**, which always use `Base58` multibase encoding.
