### PR TITLE
Fix multihash

### DIFF
--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -111,9 +111,7 @@ namespace libp2p::multi {
      * hash itself
      */
     std::vector<uint8_t> data_;
-    uint8_t hash_offset_{};
-    // does not store hash itself, points on data_
-//    gsl::span<const uint8_t> hash_;
+    uint8_t hash_offset_{};  ///< size of non-hash data from the beginning
     HashType type_;
   };
 

--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -111,8 +111,9 @@ namespace libp2p::multi {
      * hash itself
      */
     std::vector<uint8_t> data_;
+    uint8_t hash_offset_{};
     // does not store hash itself, points on data_
-    gsl::span<const uint8_t> hash_;
+//    gsl::span<const uint8_t> hash_;
     HashType type_;
   };
 

--- a/src/multi/multihash.cpp
+++ b/src/multi/multihash.cpp
@@ -46,9 +46,6 @@ namespace libp2p::multi {
     data_.push_back(static_cast<uint8_t>(hash.size()));
     hash_offset_ = data_.size();
     data_.insert(data_.end(), hash.begin(), hash.end());
-
-    // hash_ points to a data_.begin() + size ... data_.end()
-//    hash_ = gsl::span<const uint8_t>(data_).subspan(size);
   }
 
   outcome::result<Multihash> Multihash::create(HashType type,

--- a/src/multi/multihash.cpp
+++ b/src/multi/multihash.cpp
@@ -44,11 +44,11 @@ namespace libp2p::multi {
     data_.insert(data_.end(), bytes.begin(), bytes.end());
     BOOST_ASSERT(hash.size() <= std::numeric_limits<uint8_t>::max());
     data_.push_back(static_cast<uint8_t>(hash.size()));
-    size_t size = data_.size();
+    hash_offset_ = data_.size();
     data_.insert(data_.end(), hash.begin(), hash.end());
 
     // hash_ points to a data_.begin() + size ... data_.end()
-    hash_ = gsl::span<const uint8_t>(data_).subspan(size);
+//    hash_ = gsl::span<const uint8_t>(data_).subspan(size);
   }
 
   outcome::result<Multihash> Multihash::create(HashType type,
@@ -93,7 +93,7 @@ namespace libp2p::multi {
   }
 
   gsl::span<const uint8_t> Multihash::getHash() const {
-    return hash_;
+    return gsl::span<const uint8_t>(data_).subspan(hash_offset_);
   }
 
   std::string Multihash::toHex() const {
@@ -113,8 +113,8 @@ namespace libp2p::multi {
   }
 
   bool Multihash::operator<(const class libp2p::multi::Multihash &other) const {
-    return this->type_ < other.type_ ||
-        (this->type_ == other.type_ && this->data_ < other.data_);
+    return this->type_ < other.type_
+        || (this->type_ == other.type_ && this->data_ < other.data_);
   }
 
 }  // namespace libp2p::multi


### PR DESCRIPTION
Multihash has a serious issue. 
It contains as a member a gsl::span<> pointing to another member.
When another class A has multihash member, assigning its instance is risky.
If you create a temp instance, assign it to a permanent variable, the span is copied,  and then after destroying temp instance, the span starts to paint to invalid memory.
Multihash doesn't have a copy constructor, and it cannot be specified easily (I tried, but it broke some other things). 
I suppose we should get rid of keeping span as member, creating it when required, since it is a lightweight operation.
