### PR TITLE
Hotfix/streams

### DIFF
--- a/include/libp2p/common/trace.hpp
+++ b/include/libp2p/common/trace.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <libp2p/common/logger.hpp>
+
+#ifndef LIBP2P_COMMON_TRACE_HPP
+#define LIBP2P_COMMON_TRACE_HPP
+
+namespace libp2p::common {
+
+  /// Special debug utility function, allows for not having logger as member
+  /// field
+  template <typename... Args>
+  inline void traceToDebugLogger(spdlog::string_view_t fmt,
+                                 const Args &... args) {
+    static const std::string tag("debug");
+    auto log = common::createLogger(tag);
+    log->trace(fmt, args...);
+  }
+
+}  // namespace libp2p::common
+
+#if TRACE_ENABLED
+#define TRACE(...) libp2p::common::traceToDebugLogger(__VA_ARGS__)
+#else
+#define TRACE(...)
+#endif
+
+#endif  // LIBP2P_COMMON_TRACE_HPP

--- a/include/libp2p/common/trace.hpp
+++ b/include/libp2p/common/trace.hpp
@@ -10,8 +10,10 @@
 
 namespace libp2p::common {
 
-  /// Special debug utility function, allows for not having logger as member
-  /// field
+  /**
+   * Special debug utility function, allows for not having logger as member
+   * field
+   */
   template <typename... Args>
   inline void traceToDebugLogger(spdlog::string_view_t fmt,
                                  const Args &... args) {

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -117,9 +117,23 @@ namespace libp2p::connection {
 
     /// is the stream reading right now?
     bool is_reading_ = false;
+    ReadCallbackFunc read_cb_;
+    void beginRead(ReadCallbackFunc cb);
+    void endRead(outcome::result<size_t> result);
+
+    /// Tries to consume requested bytes from already received data
+    outcome::result<size_t> tryConsumeReadBuffer(gsl::span<uint8_t> out,
+                                                 size_t bytes, bool some);
+
+    /// Forwards read buffer and receive window and acknowledges
+    /// bytes received in async manner
+    void sendAck(size_t bytes);
 
     /// is the stream writing right now?
     bool is_writing_ = false;
+    WriteCallbackFunc write_cb_;
+    void beginWrite(WriteCallbackFunc cb);
+    void endWrite(outcome::result<size_t> result);
 
     /// YamuxedConnection API starts here
     friend class YamuxedConnection;
@@ -137,6 +151,9 @@ namespace libp2p::connection {
      */
     outcome::result<void> commitData(gsl::span<const uint8_t> data,
                                      size_t data_size);
+
+    /// Called by connection on reset
+    void onConnectionReset(outcome::result<size_t> reason);
   };
 }  // namespace libp2p::connection
 

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -90,7 +90,10 @@ namespace libp2p::connection {
     void write(gsl::span<const uint8_t> in, size_t bytes, WriteCallbackFunc cb,
                bool some);
 
+    /// this stream's connection
     std::weak_ptr<YamuxedConnection> yamuxed_connection_;
+
+    /// id of this stream
     YamuxedConnection::StreamId stream_id_;
 
     /// is the stream opened for reads?
@@ -99,8 +102,10 @@ namespace libp2p::connection {
     /// is the stream opened for writes?
     bool is_writable_ = true;
 
-    /// default sliding window size of the stream - how much unread bytes can be
-    /// on both sides
+    /**
+     * default sliding window size of the stream - how much unread bytes can be
+     * on both sides
+     */
     static constexpr uint32_t kDefaultWindowSize = 256 * 1024;  // in bytes
 
     /// how much unacked bytes can we have on our side
@@ -117,22 +122,47 @@ namespace libp2p::connection {
 
     /// is the stream reading right now?
     bool is_reading_ = false;
+
+    /// read callback, non-zero during async data receive
     ReadCallbackFunc read_cb_;
-    void beginRead(ReadCallbackFunc cb);
+
+    /// client's read buffer
+    gsl::span<uint8_t> external_read_buffer_;
+
+    /// bytes count client is waiting for, non-zero during async data receive
+    size_t bytes_waiting_ = 0;
+
+    /// client makes readSome operation
+    bool reading_some_ = false;
+
+    /// starts async read operation
+    void beginRead(ReadCallbackFunc cb, gsl::span<uint8_t> out, size_t bytes,
+                   bool some);
+
+    /// ends async read operation
     void endRead(outcome::result<size_t> result);
 
     /// Tries to consume requested bytes from already received data
     outcome::result<size_t> tryConsumeReadBuffer(gsl::span<uint8_t> out,
                                                  size_t bytes, bool some);
 
-    /// Forwards read buffer and receive window and acknowledges
-    /// bytes received in async manner
+    /**
+     * Forwards read buffer and receive window and acknowledges bytes received
+     * in async manner
+     * @param bytes number of bytes to ack
+     */
     void sendAck(size_t bytes);
 
     /// is the stream writing right now?
     bool is_writing_ = false;
+
+    /// write callback, non-zero during async sends
     WriteCallbackFunc write_cb_;
+
+    /// starts async write operation
     void beginWrite(WriteCallbackFunc cb);
+
+    /// ends async write operation
     void endWrite(outcome::result<size_t> result);
 
     /// YamuxedConnection API starts here

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -39,7 +39,8 @@ namespace libp2p::connection {
       TOO_MANY_STREAMS,
       FORBIDDEN_CALL,
       OTHER_SIDE_ERROR,
-      INTERNAL_ERROR
+      INTERNAL_ERROR,
+      CLOSED_BY_PEER
     };
 
     /**
@@ -104,9 +105,6 @@ namespace libp2p::connection {
     // indicates whether start() has been executed or not
     bool started_ = false;
 
-    // XXX
-    bool new_stream_pending_ = false;
-
     /**
      * Write message to the connection; ensures no more than one wright
      * would be executed at one time
@@ -169,7 +167,7 @@ namespace libp2p::connection {
     /**
      * Reset all streams, which were created over this connection
      */
-    void resetAllStreams();
+    void resetAllStreams(outcome::result<void> reason);
 
     /**
      * Find stream with such id in local streams
@@ -236,7 +234,7 @@ namespace libp2p::connection {
     /**
      * Close this Yamux session
      */
-    void closeSession();
+    void closeSession(outcome::result<void> reason);
 
     std::shared_ptr<SecureConnection> connection_;
     NewStreamHandlerFunc new_stream_handler_;

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -40,7 +40,7 @@ namespace libp2p::connection {
       FORBIDDEN_CALL,
       OTHER_SIDE_ERROR,
       INTERNAL_ERROR,
-      CLOSED_BY_PEER
+      CLOSED_BY_PEER,
     };
 
     /**
@@ -236,11 +236,19 @@ namespace libp2p::connection {
      */
     void closeSession(outcome::result<void> reason);
 
+    /// Underlying connection
     std::shared_ptr<SecureConnection> connection_;
+
+    /// Handler for new inbound streams
     NewStreamHandlerFunc new_stream_handler_;
+
+    /// Config constants
     muxer::MuxedConnectionConfig config_;
 
+    /// Last stream id to be incremented
     uint32_t last_created_stream_id_;
+
+    /// Streams
     std::unordered_map<StreamId, std::shared_ptr<YamuxStream>> streams_;
 
     libp2p::common::Logger log_ = libp2p::common::createLogger("yx-conn");
@@ -262,18 +270,6 @@ namespace libp2p::connection {
      */
     void streamOnWindowUpdate(StreamId stream_id, NotifyeeCallback cb);
     std::map<StreamId, NotifyeeCallback> window_updates_subs_;
-
-    /**
-     * Add a handler function, which is called, when data for a particular
-     * stream is received
-     * @param stream_id of the stream which is to be notified
-     * @param handler to be called; if it returns true, it's removed from
-     * the list of handlers for that stream
-     * @note this is done through a function and not event emitters, as each
-     * stream is to receive that event independently based on id
-     */
-    void streamOnAddData(StreamId stream_id, NotifyeeCallback cb);
-    std::map<StreamId, NotifyeeCallback> data_subs_;
 
     /**
      * Write bytes to the connection; before calling this method, the stream

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -8,6 +8,7 @@
 
 #include <libp2p/network/connection_manager.hpp>
 #include <libp2p/network/dialer.hpp>
+#include <libp2p/network/listener_manager.hpp>
 #include <libp2p/network/transport_manager.hpp>
 #include <libp2p/protocol_muxer/protocol_muxer.hpp>
 
@@ -19,7 +20,8 @@ namespace libp2p::network {
 
     DialerImpl(std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect,
                std::shared_ptr<TransportManager> tmgr,
-               std::shared_ptr<ConnectionManager> cmgr);
+               std::shared_ptr<ConnectionManager> cmgr,
+               std::shared_ptr<ListenerManager> listener);
 
     // Establishes a connection to a given peer
     void dial(const peer::PeerInfo &p, DialResultFunc cb) override;
@@ -33,8 +35,7 @@ namespace libp2p::network {
     std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect_;
     std::shared_ptr<TransportManager> tmgr_;
     std::shared_ptr<ConnectionManager> cmgr_;
-
-    common::Logger log_ = common::createLogger("debug"); // XXX
+    std::shared_ptr<ListenerManager> listener_;
   };
 
 }  // namespace libp2p::network

--- a/include/libp2p/network/impl/listener_manager_impl.hpp
+++ b/include/libp2p/network/impl/listener_manager_impl.hpp
@@ -50,6 +50,10 @@ namespace libp2p::network {
 
     Router &getRouter() override;
 
+    void onConnection(
+        outcome::result<std::shared_ptr<connection::CapableConnection>> rconn)
+        override;
+
    private:
     bool started = false;
 
@@ -61,9 +65,6 @@ namespace libp2p::network {
     std::shared_ptr<network::Router> router_;
     std::shared_ptr<TransportManager> tmgr_;
     std::shared_ptr<ConnectionManager> cmgr_;
-
-    void onConnection(
-        outcome::result<std::shared_ptr<connection::CapableConnection>> rconn);
   };
 
 }  // namespace libp2p::network

--- a/include/libp2p/network/impl/network_impl.hpp
+++ b/include/libp2p/network/impl/network_impl.hpp
@@ -15,7 +15,7 @@ namespace libp2p::network {
    public:
     ~NetworkImpl() override = default;
 
-    NetworkImpl(std::unique_ptr<ListenerManager> listener,
+    NetworkImpl(std::shared_ptr<ListenerManager> listener,
                 std::unique_ptr<Dialer> dialer,
                 std::shared_ptr<ConnectionManager> cmgr);
 
@@ -28,7 +28,7 @@ namespace libp2p::network {
     ConnectionManager &getConnectionManager() override;
 
    private:
-    std::unique_ptr<ListenerManager> listener_;
+    std::shared_ptr<ListenerManager> listener_;
     std::unique_ptr<Dialer> dialer_;
     std::shared_ptr<ConnectionManager> cmgr_;
   };

--- a/include/libp2p/network/listener_manager.hpp
+++ b/include/libp2p/network/listener_manager.hpp
@@ -11,8 +11,8 @@
 #include <libp2p/event/bus.hpp>
 #include <libp2p/multi/multiaddress.hpp>
 #include <libp2p/network/router.hpp>
-#include <libp2p/protocol/base_protocol.hpp>
 #include <libp2p/outcome/outcome.hpp>
+#include <libp2p/protocol/base_protocol.hpp>
 
 namespace libp2p::network {
 
@@ -117,6 +117,13 @@ namespace libp2p::network {
      * @brief Getter for Router.
      */
     virtual Router &getRouter() = 0;
+
+    /**
+     * @brief Allows new connections for accepting incoming streams
+     */
+    virtual void onConnection(
+        outcome::result<std::shared_ptr<connection::CapableConnection>>
+            rconn) = 0;
   };
 
 }  // namespace libp2p::network

--- a/src/muxer/yamux/yamux_frame.cpp
+++ b/src/muxer/yamux/yamux_frame.cpp
@@ -8,6 +8,9 @@
 #include <libp2p/common/byteutil.hpp>
 #include <libp2p/muxer/yamux/yamux_frame.hpp>
 
+#define TRACE_ENABLED 0
+#include <libp2p/common/trace.hpp>
+
 namespace libp2p::connection {
   YamuxFrame::ByteArray YamuxFrame::frameBytes(uint8_t version, FrameType type,
                                                Flag flag, uint32_t stream_id,
@@ -34,24 +37,28 @@ namespace libp2p::connection {
   }
 
   YamuxFrame::ByteArray newStreamMsg(YamuxFrame::StreamId stream_id) {
+    TRACE("yamux newStreamMsg, stream_id={}", stream_id);
     return YamuxFrame::frameBytes(YamuxFrame::kDefaultVersion,
                                   YamuxFrame::FrameType::DATA,
                                   YamuxFrame::Flag::SYN, stream_id, 0);
   }
 
   YamuxFrame::ByteArray ackStreamMsg(YamuxFrame::StreamId stream_id) {
+    TRACE("yamux ackStreamMsg, stream_id={}", stream_id);
     return YamuxFrame::frameBytes(YamuxFrame::kDefaultVersion,
                                   YamuxFrame::FrameType::DATA,
                                   YamuxFrame::Flag::ACK, stream_id, 0);
   }
 
   YamuxFrame::ByteArray closeStreamMsg(YamuxFrame::StreamId stream_id) {
+    TRACE("yamux closeStreamMsg, stream_id={}", stream_id);
     return YamuxFrame::frameBytes(YamuxFrame::kDefaultVersion,
                                   YamuxFrame::FrameType::DATA,
                                   YamuxFrame::Flag::FIN, stream_id, 0);
   }
 
   YamuxFrame::ByteArray resetStreamMsg(YamuxFrame::StreamId stream_id) {
+    TRACE("yamux resetStreamMsg, stream_id={}", stream_id);
     return YamuxFrame::frameBytes(YamuxFrame::kDefaultVersion,
                                   YamuxFrame::FrameType::DATA,
                                   YamuxFrame::Flag::RST, stream_id, 0);
@@ -71,6 +78,7 @@ namespace libp2p::connection {
 
   YamuxFrame::ByteArray dataMsg(YamuxFrame::StreamId stream_id,
                                 gsl::span<const uint8_t> data) {
+    TRACE("yamux dataMsg, stream_id={}, size={}", stream_id, data.size());
     return YamuxFrame::frameBytes(YamuxFrame::kDefaultVersion,
                                   YamuxFrame::FrameType::DATA,
                                   YamuxFrame::Flag::NONE, stream_id,
@@ -78,6 +86,7 @@ namespace libp2p::connection {
   }
 
   YamuxFrame::ByteArray goAwayMsg(YamuxFrame::GoAwayError error) {
+    TRACE("yamux goAwayMsg");
     return YamuxFrame::frameBytes(
         YamuxFrame::kDefaultVersion, YamuxFrame::FrameType::GO_AWAY,
         YamuxFrame::Flag::NONE, 0, static_cast<uint32_t>(error));

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -55,11 +55,15 @@ namespace libp2p::connection {
     return read(out, bytes, std::move(cb), true);
   }
 
-  void YamuxStream::beginRead(ReadCallbackFunc cb) {
+  void YamuxStream::beginRead(ReadCallbackFunc cb, gsl::span<uint8_t> out,
+                              size_t bytes, bool some) {
     assert(!is_reading_);
     assert(!read_cb_);
     TRACE("yamux stream {} beginRead", stream_id_);
     read_cb_ = std::move(cb);
+    external_read_buffer_ = out;
+    bytes_waiting_ = bytes;
+    reading_some_ = some;
     is_reading_ = true;
   }
 
@@ -68,6 +72,8 @@ namespace libp2p::connection {
 
     // N.B. reentrancy of read_cb_{read} is allowed
     is_reading_ = false;
+    bytes_waiting_ = 0;
+    reading_some_ = false;
     if (read_cb_) {
       auto cb = std::move(read_cb_);
       read_cb_ = ReadCallbackFunc{};
@@ -79,6 +85,8 @@ namespace libp2p::connection {
       gsl::span<uint8_t> out, size_t bytes, bool some) {
     // will try to consume n bytes if applicable
     auto n = std::min(read_buffer_.size(), bytes);
+
+    TRACE("stream {}: need {} bytes, available {} bytes", stream_id_, bytes, n);
 
     if ((some && n > 0) || (!some && n == bytes)) {
       auto copied = boost::asio::buffer_copy(boost::asio::buffer(out.data(), n),
@@ -132,29 +140,15 @@ namespace libp2p::connection {
     // is_readable_ flag is set due to FIN flag from the other side.
     // Nevertheless, unconsumed data may exist at the moment
     if (!is_readable_) {
-      return cb(Error::NOT_READABLE);
+      return endRead(Error::NOT_READABLE);
     }
 
     if (yamuxed_connection_.expired()) {
-      return cb(Error::CONNECTION_IS_DEAD);
+      return endRead(Error::CONNECTION_IS_DEAD);
     }
 
     // cannot return immediately, wait for incoming data
-    beginRead(std::move(cb));
-
-    yamuxed_connection_.lock()->streamOnAddData(
-        stream_id_, [self{shared_from_this()}, out, bytes, some]() {
-          // if there is enough data in our buffer (depending if we want to read
-          // some or all bytes), read it
-
-          auto res = self->tryConsumeReadBuffer(out, bytes, some);
-          if (res && res.value() == 0) {
-            // not enough data received
-            return false;
-          }
-          self->endRead(res);
-          return true;
-        });
+    beginRead(std::move(cb), out, bytes, some);
   }
 
   void YamuxStream::write(gsl::span<const uint8_t> in, size_t bytes,
@@ -344,15 +338,49 @@ namespace libp2p::connection {
       return Error::RECEIVE_OVERFLOW;
     }
 
-    if (boost::asio::buffer_copy(
-            read_buffer_.prepare(data_size),
-            boost::asio::const_buffer(data.data(), data_size))
-        != data_size) {
-      return Error::INTERNAL_ERROR;
+    size_t bytes_remain = data_size;
+    bool inplace_readop = false;
+
+    if (read_buffer_.size() == 0 && bytes_waiting_ > 0) {
+      // will try to consume n bytes w/o copying to intermediate buffer
+      auto n = std::min(data_size, bytes_waiting_);
+
+      TRACE("stream {}: need {} bytes, available {} bytes", stream_id_,
+            bytes_waiting_, n);
+
+      if ((reading_some_ && n > 0) || (!reading_some_ && n == bytes_waiting_)) {
+        memcpy(external_read_buffer_.data(), data.data(), n);
+        sendAck(n);
+        bytes_remain -= n;
+        inplace_readop = true;
+      }
     }
-    read_buffer_.commit(data_size);
+
+    if (bytes_remain > 0) {
+      if (boost::asio::buffer_copy(
+              read_buffer_.prepare(bytes_remain),
+              boost::asio::const_buffer(data.data() + data_size - bytes_remain,
+                                        bytes_remain))
+          != bytes_remain) {
+        return Error::INTERNAL_ERROR;
+      }
+      read_buffer_.commit(bytes_remain);
+    }
 
     receive_window_size_ -= data_size;
+
+    if (inplace_readop) {
+      assert(read_cb_);
+      assert(data_size - bytes_remain > 0);
+      endRead(data_size - bytes_remain);
+    } else if (bytes_waiting_ > 0) {
+      assert(read_cb_);
+      auto res = tryConsumeReadBuffer(external_read_buffer_, bytes_waiting_,
+                                      reading_some_);
+      if (!res || res.value() > 0) {
+        endRead(res);
+      }
+    }
 
     return outcome::success();
   }

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -200,13 +200,14 @@ namespace libp2p::connection {
         if (conn_wptr.expired()) {
           self->endWrite(Error::CONNECTION_IS_DEAD);
         } else {
-          conn_wptr.lock()->streamWrite(
-              self->stream_id_, in, bytes, some, [self](auto &&res) {
-                if (res) {
-                  self->send_window_size_ -= res.value();
-                }
-                self->endWrite(std::forward<decltype(res)>(res));
-              });
+          conn_wptr.lock()->streamWrite(self->stream_id_, in, bytes, some,
+                                        [self](outcome::result<size_t> res) {
+                                          if (res) {
+                                            self->send_window_size_ -=
+                                                res.value();
+                                          }
+                                          self->endWrite(res);
+                                        });
         }
         return true;
       }

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -124,7 +124,6 @@ namespace libp2p::connection {
     resetAllStreams(Error::YAMUX_IS_CLOSED);
     streams_.clear();
     window_updates_subs_.clear();
-//    data_subs_.clear();
     return connection_->close();
   }
 

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -12,8 +12,6 @@
 #define TRACE_ENABLED 0
 #include <libp2p/common/trace.hpp>
 
-using Buffer = libp2p::common::ByteArray;
-
 OUTCOME_CPP_DEFINE_CATEGORY(libp2p::connection, YamuxedConnection::Error, e) {
   using ErrorType = libp2p::connection::YamuxedConnection::Error;
   switch (e) {

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -124,7 +124,7 @@ namespace libp2p::connection {
     resetAllStreams(Error::YAMUX_IS_CLOSED);
     streams_.clear();
     window_updates_subs_.clear();
-    data_subs_.clear();
+//    data_subs_.clear();
     return connection_->close();
   }
 
@@ -418,14 +418,6 @@ namespace libp2p::connection {
             return self->doReadHeader();
           }
 
-          if (auto stream_data_sub = self->data_subs_.find(frame.stream_id);
-              stream_data_sub != self->data_subs_.end()) {
-            // if someone is waiting for the data from that stream, notify it
-            if (stream_data_sub->second()) {
-              self->data_subs_.erase(stream_data_sub);
-            }
-          }
-
           self->doReadHeader();
         });
   }
@@ -507,11 +499,6 @@ namespace libp2p::connection {
   void YamuxedConnection::streamOnWindowUpdate(StreamId stream_id,
                                                NotifyeeCallback cb) {
     window_updates_subs_[stream_id] = std::move(cb);
-  }
-
-  void YamuxedConnection::streamOnAddData(StreamId stream_id,
-                                          NotifyeeCallback cb) {
-    data_subs_[stream_id] = std::move(cb);
   }
 
   void YamuxedConnection::streamWrite(StreamId stream_id,

--- a/src/network/impl/dialer_impl.cpp
+++ b/src/network/impl/dialer_impl.cpp
@@ -7,24 +7,26 @@
 #include <libp2p/connection/stream.hpp>
 #include <libp2p/network/impl/dialer_impl.hpp>
 
+#define TRACE_ENABLED 0
+#include <libp2p/common/trace.hpp>
+
 namespace libp2p::network {
 
   void DialerImpl::dial(const peer::PeerInfo &p, DialResultFunc cb) {
     if (auto c = cmgr_->getBestConnectionForPeer(p.id); c != nullptr) {
       // we have connection to this peer
-      log_->debug("dialer: found reusable connection");
 
-      if (c->isInitiator()) {
-        // TODO(artem): dont reuse connections in opposite direction temporarily
-        return cb(std::move(c));
-      }
+      TRACE("reusing connection to peer {}", p.id.toBase58().substr(46));
+      cb(std::move(c));
+      return;
     }
 
     // we don't have a connection to this peer.
     // did user supply its addresses in {@param p}?
     if (p.addresses.empty()) {
       // we don't have addresses of peer p
-      return cb(std::errc::destination_address_required);
+      cb(std::errc::destination_address_required);
+      return;
     }
 
     // for all multiaddresses supplied in peerinfo
@@ -33,33 +35,35 @@ namespace libp2p::network {
       if (auto tr = this->tmgr_->findBest(ma); tr != nullptr) {
         // we can dial to this peer!
         // dial using best transport
-        return tr->dial(
+        tr->dial(
             p.id, ma,
             [this, cb{std::move(cb)}, pid{p.id}](
                 outcome::result<std::shared_ptr<connection::CapableConnection>>
                     rconn) {
               if (!rconn) {
-                return cb(rconn.error());
+                cb(rconn.error());
+                return;
               }
 
-              auto &&conn = rconn.value();
-              this->cmgr_->addConnectionToPeer(pid, conn);
+              // allow the connection to accept inbound streams
+              this->listener_->onConnection(rconn);
 
               // return connection to the user
-              cb(conn);
+              cb(rconn.value());
             });
+        return;
       }
     }
 
     // we did not find supported transport
-    return cb(std::errc::address_family_not_supported);
+    cb(std::errc::address_family_not_supported);
   }
 
   void DialerImpl::newStream(const peer::PeerInfo &p,
                              const peer::Protocol &protocol,
                              StreamResultFunc cb) {
     // 1. make new connection or reuse existing
-    return this->dial(
+    this->dial(
         p,
         [this, cb{std::move(cb)}, protocol](
             outcome::result<std::shared_ptr<connection::CapableConnection>>
@@ -70,8 +74,7 @@ namespace libp2p::network {
           auto &&conn = rconn.value();
 
           if (!conn->isInitiator()) {
-            log_->debug(
-                "dialer: opening outbound stream inside inbound connection");
+            TRACE("dialer: opening outbound stream inside inbound connection");
           }
 
           // 2. open new stream on that connection
@@ -84,7 +87,7 @@ namespace libp2p::network {
                 }
                 auto &&stream = rstream.value();
 
-                log_->debug("dialer: inside newStream callback");
+                TRACE("dialer: before multiselect");
 
                 // 3. negotiate a protocol over that stream
                 std::vector<peer::Protocol> protocols{protocol};
@@ -96,6 +99,8 @@ namespace libp2p::network {
                         return cb(rproto.error());
                       }
 
+                      TRACE("dialer: inside multiselect callback");
+
                       // 4. return stream back to the user
                       cb(std::move(stream));
                     });
@@ -106,13 +111,16 @@ namespace libp2p::network {
   DialerImpl::DialerImpl(
       std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect,
       std::shared_ptr<TransportManager> tmgr,
-      std::shared_ptr<ConnectionManager> cmgr)
+      std::shared_ptr<ConnectionManager> cmgr,
+      std::shared_ptr<ListenerManager> listener)
       : multiselect_(std::move(multiselect)),
         tmgr_(std::move(tmgr)),
-        cmgr_(std::move(cmgr)) {
+        cmgr_(std::move(cmgr)),
+        listener_(std::move(listener)) {
     BOOST_ASSERT(multiselect_ != nullptr);
     BOOST_ASSERT(tmgr_ != nullptr);
     BOOST_ASSERT(cmgr_ != nullptr);
+    BOOST_ASSERT(listener_ != nullptr);
   }
 
 }  // namespace libp2p::network

--- a/src/network/impl/network_impl.cpp
+++ b/src/network/impl/network_impl.cpp
@@ -23,7 +23,7 @@ namespace libp2p::network {
     return *cmgr_;
   }
 
-  NetworkImpl::NetworkImpl(std::unique_ptr<ListenerManager> listener,
+  NetworkImpl::NetworkImpl(std::shared_ptr<ListenerManager> listener,
                            std::unique_ptr<Dialer> dialer,
                            std::shared_ptr<ConnectionManager> cmgr)
       : listener_(std::move(listener)),

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -159,10 +159,11 @@ Peer::sptr<host::BasicHost> Peer::makeHost(const crypto::KeyPair &keyPair) {
 
   auto cmgr = std::make_shared<network::ConnectionManagerImpl>(bus, tmgr);
 
-  auto listener = std::make_unique<network::ListenerManagerImpl>(
+  auto listener = std::make_shared<network::ListenerManagerImpl>(
       multiselect, std::move(router), tmgr, cmgr);
 
-  auto dialer = std::make_unique<network::DialerImpl>(multiselect, tmgr, cmgr);
+  auto dialer =
+      std::make_unique<network::DialerImpl>(multiselect, tmgr, cmgr, listener);
 
   auto network = std::make_unique<network::NetworkImpl>(
       std::move(listener), std::move(dialer), cmgr);

--- a/test/libp2p/protocol/kademlia/node_id_test.cpp
+++ b/test/libp2p/protocol/kademlia/node_id_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <iostream>
+#include <cstdlib>
 #include <libp2p/common/hexutil.hpp>
 #include <libp2p/common/literals.hpp>
 #include "testutil/libp2p/peer.hpp"
@@ -17,6 +18,13 @@ using libp2p::peer::PeerId;
 using libp2p::protocol::kademlia::NodeId;
 using libp2p::protocol::kademlia::xor_distance;
 using libp2p::protocol::kademlia::XorDistanceComparator;
+
+// allows to print debug output to stdout, not wanted in CI output, but
+// useful while debugging
+bool verbose() {
+  static const bool v = (std::getenv("TRACE_DEBUG") != nullptr);
+  return v;
+}
 
 bool is_distance_less(Hash256 a, Hash256 b) {
   constexpr auto size = Hash256().size();
@@ -48,6 +56,7 @@ bool is_xor_distance_sorted(const PeerId &local, std::vector<PeerId> &peers) {
 }
 
 void print(NodeId from, std::vector<PeerId> &pids) {
+  if (!verbose()) return;
   std::cout << "peers: \n";
   for (auto &p : pids) {
     std::cout << "pid: " << p.toHex()

--- a/test/mock/libp2p/network/listener_mock.hpp
+++ b/test/mock/libp2p/network/listener_mock.hpp
@@ -43,6 +43,9 @@ namespace libp2p::network {
                  outcome::result<void>(const multi::Multiaddress &));
 
     MOCK_METHOD0(getRouter, Router &());
+
+    MOCK_METHOD1(onConnection, void(
+        outcome::result<std::shared_ptr<connection::CapableConnection>>));
   };
 }  // namespace libp2p::network
 


### PR DESCRIPTION
Hotfixes to ya-muxer and stream dialer:
1/ Outbound connection is able to accept inbound streams from remote peer during its lifetime;
2/ Streams get notified on connection close events (eof and other reasons) if they have pending read or write operations